### PR TITLE
Add SSHFS-based volume mounting for bidirectional file sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ AGENTS.md
 .aider*
 .continue/
 copilot-*
+
+# project
+spuff.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ copilot-*
 
 # project
 spuff.yaml
+data/
+data-*/

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ sudo cp target/release/spuff /usr/local/bin/
 spuff init
 ```
 
-This creates `~/.config/spuff/config.yaml` with your preferences.
+This creates `~/.spuff/config.yaml` with your preferences.
 
 ### 2. Set your cloud provider token
 
@@ -171,7 +171,7 @@ spuff exec "uname -a"       # Run command on remote
 
 ## Configuration
 
-Configuration lives at `~/.config/spuff/config.yaml`:
+Configuration lives at `~/.spuff/config.yaml`:
 
 ```yaml
 provider: digitalocean

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ A single CLI that provisions a cloud VM with your dev environment, connects you 
 | **Tailscale Integration** | ✅ | Private networking without exposing ports |
 | **Remote Agent** | ✅ | Monitor CPU, memory, processes from CLI |
 | **Dotfiles Sync** | ✅ | Your shell config, everywhere |
+| **Volume Mounts (SSHFS)** | ✅ | Bidirectional file sync between local and remote |
+| **Port Tunneling** | ✅ | Forward remote ports to localhost |
 | **Multi-cloud** | 🚧 | DigitalOcean ✅, Hetzner 🚧, AWS 🚧 |
 | **Devbox/Nix** | 🚧 | Reproducible environments |
 
@@ -153,6 +155,11 @@ spuff agent logs -n 50      # Last 50 lines
 spuff agent devtools status   # Show devtools installation progress
 spuff agent devtools install  # Trigger devtools installation
 
+# Volume mounts (SSHFS)
+spuff volume mount ./src /home/dev/project  # Mount local dir on remote
+spuff volume unmount /home/dev/project      # Unmount a volume
+spuff volume ls                             # List active mounts
+
 # Configuration
 spuff config show           # Display current config
 spuff config set region nyc3
@@ -191,30 +198,45 @@ tailscale_authkey: tskey-auth-xxx  # or use TS_AUTHKEY env var
 
 ## Architecture
 
-```
-┌─────────────────┐         ┌──────────────────────────────────┐
-│   Your Machine  │         │        Cloud VM                  │
-│                 │         │                                  │
-│  ┌───────────┐  │   SSH   │  ┌────────────┐  ┌────────────┐ │
-│  │  spuff    │──┼────────►│  │   sshd     │  │   Docker   │ │
-│  │   CLI     │  │    -A   │  └────────────┘  └────────────┘ │
-│  └───────────┘  │         │                                  │
-│                 │         │  ┌────────────────────────────┐  │
-│  SSH Agent ─────┼────────►│  │      spuff-agent          │  │
-│  (keys)         │ forward │  │  • metrics & monitoring   │  │
-│                 │         │  │  • idle detection         │  │
-└─────────────────┘         │  │  • devtools installation  │  │
-                            │  └────────────────────────────┘  │
-                            │                                  │
-                            │  cloud-init: essentials + agent  │
-                            └──────────────────────────────────┘
+```mermaid
+flowchart LR
+    subgraph local["Your Machine"]
+        cli["spuff CLI"]
+        agent_keys["SSH Agent<br/>(keys)"]
+        sshfs["SSHFS<br/>Mount"]
+        localdir[("~/project")]
+    end
+
+    subgraph cloud["Cloud VM"]
+        sshd["sshd"]
+        subgraph services["Services"]
+            docker["Docker"]
+            tailscale["Tailscale"]
+        end
+        subgraph spuff_agent["spuff-agent :7575"]
+            metrics["metrics"]
+            idle["idle detection"]
+            devtools["devtools"]
+            volumes["volume manager"]
+        end
+        remotedir[("/home/dev/project")]
+    end
+
+    cli -->|"SSH -A"| sshd
+    agent_keys -.->|"forward"| sshd
+    cli -->|"tunnel :7575"| spuff_agent
+    cli -->|"port forward"| services
+    sshfs <-->|"bidirectional sync"| remotedir
+    localdir --- sshfs
 ```
 
 **Components:**
 
 - **spuff CLI** — Local tool for managing environments
-- **spuff-agent** — Daemon running on VM for monitoring, devtools installation, and management
-- **cloud-init** — Fast bootstrap with essentials (~30s), devtools installed async via agent
+- **spuff-agent** — Daemon on VM for metrics, idle detection, devtools, and volume management
+- **SSHFS** — Bidirectional file sync between local and remote directories
+- **SSH Tunnels** — Port forwarding for services (databases, web servers, etc.)
+- **cloud-init** — Fast bootstrap (~30s), devtools installed async via agent
 
 ## Roadmap
 
@@ -225,6 +247,8 @@ tailscale_authkey: tskey-auth-xxx  # or use TS_AUTHKEY env var
 - [x] Idle auto-destroy
 - [x] Remote agent with metrics
 - [x] Tailscale integration
+- [x] Volume mounts (SSHFS bidirectional sync)
+- [x] Port tunneling from project config
 
 ### Next (v0.2)
 - [ ] Hetzner Cloud provider
@@ -266,18 +290,25 @@ cargo build --release
 ```
 src/
 ├── main.rs              # CLI entry point
-├── cli/                 # Command definitions
+├── cli/                 # Command definitions (up, down, ssh, volume, etc.)
 ├── config.rs            # Configuration management
+├── project_config.rs    # Per-project spuff.yaml parsing
 ├── provider/            # Cloud provider implementations
 │   ├── mod.rs           # Provider trait
 │   └── digitalocean.rs  # DigitalOcean implementation
 ├── connector/           # SSH connectivity
 ├── environment/         # Cloud-init generation
+├── volume/              # SSHFS volume management
+│   ├── config.rs        # Volume configuration
+│   ├── driver.rs        # VolumeDriver trait
+│   ├── drivers/sshfs.rs # SSHFS implementation
+│   └── state.rs         # Local mount state tracking
 ├── agent/               # Remote agent (separate binary)
 │   ├── main.rs
 │   ├── routes.rs
 │   ├── metrics.rs
-│   └── devtools.rs      # Async devtools installation manager
+│   ├── devtools.rs      # Async devtools installation manager
+│   └── volume_manager.rs # Remote volume management
 ├── state.rs             # Local SQLite state
 └── utils.rs             # Shared utilities
 ```

--- a/docs/adr/0003-sqlite-local-state.md
+++ b/docs/adr/0003-sqlite-local-state.md
@@ -35,7 +35,7 @@ This state is needed for:
 
 ## Decision
 
-We will use **SQLite** for local state management, stored at `~/.config/spuff/state.db`.
+We will use **SQLite** for local state management, stored at `~/.spuff/state.db`.
 
 ### Schema
 
@@ -110,7 +110,7 @@ impl StateDb {
 
 ### Alternative 1: JSON File
 
-Store state in a JSON file at `~/.config/spuff/state.json`.
+Store state in a JSON file at `~/.spuff/state.json`.
 
 **Pros:**
 

--- a/docs/adr/0006-project-config-spec.md
+++ b/docs/adr/0006-project-config-spec.md
@@ -10,7 +10,7 @@ Accepted
 
 ## Context
 
-spuff currently uses a global configuration file (`~/.config/spuff/config.yaml`) for all environments. While this works for basic usage, teams and projects often need:
+spuff currently uses a global configuration file (`~/.spuff/config.yaml`) for all environments. While this works for basic usage, teams and projects often need:
 
 1. **Reproducible environments** - Every developer should get the same setup
 2. **Project-specific tooling** - Different projects need different language stacks

--- a/docs/adr/0006-project-config-spec.md
+++ b/docs/adr/0006-project-config-spec.md
@@ -56,23 +56,33 @@ We will implement a **project-level configuration specification** via `spuff.yam
 
 ### 3. Implementation Architecture
 
-```
-CLI (spuff up)
-    │
-    ├─ Load spuff.yaml from CWD
-    ├─ Merge with global config
-    ├─ Embed as project.json in cloud-init
-    │
-    └─ VM boots → agent starts
-         │
-         └─ Agent reads /opt/spuff/project.json
-              │
-              ├─ Install bundles (async)
-              ├─ Install packages
-              ├─ Clone repositories
-              ├─ Start services (docker-compose)
-              ├─ Run setup scripts
-              └─ Execute hooks
+```mermaid
+flowchart TB
+    subgraph cli["CLI (spuff up)"]
+        load["Load spuff.yaml from CWD"]
+        merge["Merge with global config"]
+        embed["Embed as project.json in cloud-init"]
+        load --> merge --> embed
+    end
+
+    subgraph vm["VM boots → agent starts"]
+        read["Agent reads /opt/spuff/project.json"]
+        bundles["Install bundles (async)"]
+        packages["Install packages"]
+        repos["Clone repositories"]
+        services["Start services (docker-compose)"]
+        scripts["Run setup scripts"]
+        hooks["Execute hooks"]
+
+        read --> bundles
+        read --> packages
+        read --> repos
+        read --> services
+        packages --> scripts
+        scripts --> hooks
+    end
+
+    embed --> vm
 ```
 
 ### 4. What We Will NOT Do

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,7 +31,7 @@ flowchart TB
             ssh["SSH<br/>Connector"]
             state["State<br/>(SQLite)"]
         end
-        statedb[("~/.config/spuff/<br/>state.db")]
+        statedb[("~/.spuff/<br/>state.db")]
         stdout["stdout<br/>(TUI progress)"]
     end
 
@@ -654,7 +654,7 @@ This file is read by the agent's `/status` endpoint.
 
 Located in `src/state.rs`.
 
-**Database:** SQLite at `~/.config/spuff/state.db`
+**Database:** SQLite at `~/.spuff/state.db`
 
 ### Schema
 
@@ -959,7 +959,7 @@ From cloud-init:
 | API Token | env var or config.yaml | File permissions (0600) |
 | SSH Private Key | ~/.ssh/id_* | File permissions (0600) |
 | Agent Token | env var | Process environment |
-| State DB | ~/.config/spuff/state.db | File permissions |
+| State DB | ~/.spuff/state.db | File permissions |
 
 ---
 
@@ -1273,5 +1273,5 @@ curl -H "X-Spuff-Token: $TOKEN" http://127.0.0.1:7575/status
 ### Local State
 
 ```bash
-sqlite3 ~/.config/spuff/state.db "SELECT * FROM instances;"
+sqlite3 ~/.spuff/state.db "SELECT * FROM instances;"
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,7 +7,7 @@ This document describes all configuration options available in spuff's `config.y
 The configuration file is located at:
 
 ```
-~/.config/spuff/config.yaml
+~/.spuff/config.yaml
 ```
 
 To create or edit the configuration:
@@ -484,7 +484,7 @@ spuff up --dev
 The config file is created with restricted permissions (`0600`) to protect sensitive data like tokens. If you edit the file manually, ensure proper permissions:
 
 ```bash
-chmod 600 ~/.config/spuff/config.yaml
+chmod 600 ~/.spuff/config.yaml
 ```
 
 ---
@@ -538,7 +538,7 @@ ssh_user: ci
 ### Config not found
 
 ```
-Error: Config file not found: ~/.config/spuff/config.yaml. Run 'spuff init' first.
+Error: Config file not found: ~/.spuff/config.yaml. Run 'spuff init' first.
 ```
 
 **Solution:** Run `spuff init` to create the configuration file.

--- a/docs/development/cross-compilation.md
+++ b/docs/development/cross-compilation.md
@@ -4,31 +4,21 @@ The spuff-agent runs on Linux cloud VMs, but you might develop on macOS or Windo
 
 ## Overview
 
-```
-┌─────────────────────────────────────────────────────────────────────────────┐
-│                      Development Machine (macOS)                             │
-│                                                                              │
-│   ┌─────────────────┐        ┌─────────────────────────────────────────┐   │
-│   │   Rust Code     │───────►│  cargo zigbuild                         │   │
-│   │   (src/agent/)  │        │  --target x86_64-unknown-linux-gnu      │   │
-│   └─────────────────┘        └─────────────────────────────────────────┘   │
-│                                              │                               │
-│                                              ▼                               │
-│                              ┌─────────────────────────────────────────┐   │
-│                              │  target/x86_64-unknown-linux-gnu/       │   │
-│                              │  release/spuff-agent                    │   │
-│                              │  (Linux ELF binary)                     │   │
-│                              └─────────────────────────────────────────┘   │
-└─────────────────────────────────────────────────────────────────────────────┘
-                                               │
-                                               │ SCP/cloud-init
-                                               ▼
-┌─────────────────────────────────────────────────────────────────────────────┐
-│                           Cloud VM (Linux)                                   │
-│                                                                              │
-│   /opt/spuff/spuff-agent                                                    │
-│                                                                              │
-└─────────────────────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TB
+    subgraph dev["Development Machine (macOS)"]
+        code["Rust Code<br/>(src/agent/)"]
+        zigbuild["cargo zigbuild<br/>--target x86_64-unknown-linux-gnu"]
+        binary["target/x86_64-unknown-linux-gnu/<br/>release/spuff-agent<br/>(Linux ELF binary)"]
+
+        code --> zigbuild --> binary
+    end
+
+    subgraph vm["Cloud VM (Linux)"]
+        agent["/opt/spuff/spuff-agent"]
+    end
+
+    binary -->|"SCP / cloud-init"| agent
 ```
 
 ## Using cargo-zigbuild (Recommended)

--- a/docs/development/debugging.md
+++ b/docs/development/debugging.md
@@ -167,7 +167,7 @@ curl -X GET \
 
 ```bash
 # Open database
-sqlite3 ~/.config/spuff/state.db
+sqlite3 ~/.spuff/state.db
 
 # List tables
 .tables
@@ -188,7 +188,7 @@ SELECT * FROM instances;
 
 ```bash
 # Delete state database
-rm ~/.config/spuff/state.db
+rm ~/.spuff/state.db
 
 # Spuff will recreate on next run
 ```
@@ -309,7 +309,7 @@ State may be out of sync:
 
 ```bash
 # Check local state
-sqlite3 ~/.config/spuff/state.db "SELECT * FROM instances;"
+sqlite3 ~/.spuff/state.db "SELECT * FROM instances;"
 
 # Check provider
 curl -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
@@ -362,10 +362,10 @@ heaptrack_gui heaptrack.spuff.*.gz
 
 ```bash
 # Reset everything
-rm -rf ~/.config/spuff/
+rm -rf ~/.spuff/
 
 # Clear state, keep config
-rm ~/.config/spuff/state.db
+rm ~/.spuff/state.db
 
 # Debug logging
 RUST_LOG=spuff=debug cargo run -- <command>

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -97,7 +97,7 @@ Inspect local state database:
 brew install sqlite
 
 # View state
-sqlite3 ~/.config/spuff/state.db "SELECT * FROM instances;"
+sqlite3 ~/.spuff/state.db "SELECT * FROM instances;"
 ```
 
 ## IDE Setup
@@ -178,8 +178,8 @@ Create a test configuration:
 cargo run -- init
 
 # Or create manually
-mkdir -p ~/.config/spuff
-cat > ~/.config/spuff/config.yaml << EOF
+mkdir -p ~/.spuff
+cat > ~/.spuff/config.yaml << EOF
 provider: digitalocean
 region: nyc1
 size: s-1vcpu-1gb  # Small for testing
@@ -300,7 +300,7 @@ sudo journalctl -u spuff-agent -f
 Reset local state:
 
 ```bash
-rm ~/.config/spuff/state.db
+rm ~/.spuff/state.db
 ```
 
 ## Next Steps

--- a/docs/project-config.md
+++ b/docs/project-config.md
@@ -140,7 +140,7 @@ resources:
   region: fra1         # Region
 ```
 
-**Precedence:** CLI flags > spuff.yaml > ~/.config/spuff/config.yaml
+**Precedence:** CLI flags > spuff.yaml > ~/.spuff/config.yaml
 
 ---
 

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -4,34 +4,32 @@ Spuff uses a provider abstraction layer that enables support for multiple cloud 
 
 ## Overview
 
-```
-┌──────────────────────────────────────────────────────────────────────┐
-│                            spuff CLI                                  │
-│                                                                       │
-│  ┌─────────────────────────────────────────────────────────────────┐ │
-│  │                    Provider Registry                             │ │
-│  │                                                                  │ │
-│  │   ProviderFactory ──► create() ──► Box<dyn Provider>            │ │
-│  └─────────────────────────────────────────────────────────────────┘ │
-│                               │                                       │
-│  ┌─────────────────────────────────────────────────────────────────┐ │
-│  │                     Provider Trait                               │ │
-│  │                                                                  │ │
-│  │  create_instance()   destroy_instance()   list_instances()      │ │
-│  │  get_instance()      wait_ready()         create_snapshot()     │ │
-│  │  list_snapshots()    delete_snapshot()    get_ssh_keys()        │ │
-│  └─────────────────────────────────────────────────────────────────┘ │
-│                               │                                       │
-│         ┌─────────────────────┼─────────────────────┐                │
-│         │                     │                     │                │
-│         ▼                     ▼                     ▼                │
-│  ┌─────────────┐       ┌─────────────┐       ┌─────────────┐        │
-│  │DigitalOcean │       │   Hetzner   │       │     AWS     │        │
-│  │  Provider   │       │  Provider   │       │  Provider   │        │
-│  │   + Factory │       │  + Factory  │       │  + Factory  │        │
-│  └─────────────┘       └─────────────┘       └─────────────┘        │
-│                                                                       │
-└──────────────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TB
+    subgraph cli["spuff CLI"]
+        subgraph registry["Provider Registry"]
+            factory["ProviderFactory"]
+            create["create()"]
+            boxprovider["Box&lt;dyn Provider&gt;"]
+            factory --> create --> boxprovider
+        end
+
+        subgraph trait["Provider Trait"]
+            methods["create_instance()  destroy_instance()  list_instances()<br/>get_instance()  wait_ready()  create_snapshot()<br/>list_snapshots()  delete_snapshot()  get_ssh_keys()"]
+        end
+
+        boxprovider --> trait
+
+        subgraph providers["Implementations"]
+            do["DigitalOcean<br/>Provider + Factory"]
+            hetzner["Hetzner<br/>Provider + Factory"]
+            aws["AWS<br/>Provider + Factory"]
+        end
+
+        trait --> do
+        trait --> hetzner
+        trait --> aws
+    end
 ```
 
 ## Architecture

--- a/docs/providers/creating-a-provider.md
+++ b/docs/providers/creating-a-provider.md
@@ -33,18 +33,23 @@ Before starting, you need:
 
 The system uses two main traits:
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│                     ProviderRegistry                         │
-│                                                              │
-│   HashMap<ProviderType, Arc<dyn ProviderFactory>>           │
-│                                                              │
-│   DigitalOceanFactory ──┐                                   │
-│   HetznerFactory ───────┼──► create_by_name("hetzner")      │
-│   AwsFactory ───────────┘           │                       │
-│                                     ▼                       │
-│                          Box<dyn Provider>                   │
-└─────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart LR
+    subgraph registry["ProviderRegistry"]
+        hashmap["HashMap&lt;ProviderType, Arc&lt;dyn ProviderFactory&gt;&gt;"]
+
+        do_factory["DigitalOceanFactory"]
+        hetzner_factory["HetznerFactory"]
+        aws_factory["AwsFactory"]
+
+        create["create_by_name('hetzner')"]
+        provider["Box&lt;dyn Provider&gt;"]
+
+        do_factory --> create
+        hetzner_factory --> create
+        aws_factory --> create
+        create --> provider
+    end
 ```
 
 **You need to implement:**

--- a/docs/providers/testing-providers.md
+++ b/docs/providers/testing-providers.md
@@ -4,19 +4,12 @@ This guide covers testing strategies for cloud provider implementations.
 
 ## Testing Levels
 
-```
-┌─────────────────────────────────────────────────────────────┐
-│                    Integration Tests                         │
-│              (Real API, real resources)                      │
-│                    cargo test --ignored                      │
-└─────────────────────────────────────────────────────────────┘
-                              ▲
-                              │
-┌─────────────────────────────────────────────────────────────┐
-│                      Unit Tests                              │
-│               (Mocked API responses)                         │
-│                       cargo test                             │
-└─────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart BT
+    unit["Unit Tests<br/>(Mocked API responses)<br/>cargo test"]
+    integration["Integration Tests<br/>(Real API, real resources)<br/>cargo test --ignored"]
+
+    unit --> integration
 ```
 
 ## Unit Tests with Mocked API

--- a/docs/security.md
+++ b/docs/security.md
@@ -18,38 +18,27 @@ The security model is designed around:
 
 ## Architecture Security
 
-```
-┌─────────────────────────────────────────────────────────────────────────────┐
-│                         User's Machine (Trusted)                             │
-│                                                                              │
-│  ┌──────────────┐   ┌──────────────┐   ┌──────────────────────────────────┐ │
-│  │ API Token    │   │ SSH Keys     │   │ Local State (SQLite)             │ │
-│  │ (env var)    │   │ (filesystem) │   │ ~/.config/spuff/state.db         │ │
-│  │              │   │ 0600 perms   │   │                                  │ │
-│  └──────────────┘   └──────────────┘   └──────────────────────────────────┘ │
-│         │                  │                                                 │
-│         │                  │ SSH Agent Forwarding                            │
-│         │                  │ (keys never leave machine)                      │
-│         │                  │                                                 │
-└─────────│──────────────────│─────────────────────────────────────────────────┘
-          │                  │
-          │ HTTPS (TLS)      │ SSH (encrypted)
-          │                  │
-┌─────────│──────────────────│─────────────────────────────────────────────────┐
-│         │                  │              Cloud VM (Semi-trusted)            │
-│         │                  │                                                 │
-│         ▼                  ▼                                                 │
-│  ┌──────────────┐   ┌──────────────┐   ┌──────────────────────────────────┐ │
-│  │ Provider API │   │ SSH Server   │   │ spuff-agent                      │ │
-│  │ (external)   │   │ Port 22      │   │ Port 7575 (localhost only)       │ │
-│  └──────────────┘   └──────────────┘   │ Token auth required              │ │
-│                                         └──────────────────────────────────┘ │
-│                                                                              │
-│  No private keys stored                                                      │
-│  No API tokens stored                                                        │
-│  Ephemeral by design                                                         │
-│                                                                              │
-└──────────────────────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TB
+    subgraph trusted["User's Machine (Trusted)"]
+        token["API Token<br/>(env var)"]
+        sshkeys["SSH Keys<br/>(filesystem)<br/>0600 perms"]
+        state[("Local State<br/>~/.config/spuff/state.db")]
+    end
+
+    subgraph semitrust["Cloud VM (Semi-trusted)"]
+        providerapi["Provider API<br/>(external)"]
+        sshserver["SSH Server<br/>Port 22"]
+        agent["spuff-agent<br/>Port 7575 (localhost only)<br/>Token auth required"]
+
+        note["No private keys stored<br/>No API tokens stored<br/>Ephemeral by design"]
+    end
+
+    token -->|"HTTPS (TLS)"| providerapi
+    sshkeys -->|"SSH Agent Forwarding<br/>(keys never leave machine)"| sshserver
+    sshkeys -->|"SSH (encrypted)"| sshserver
+
+    style note fill:#f5f5f5,stroke:#ccc,stroke-dasharray: 5 5
 ```
 
 ## Threat Model

--- a/docs/security.md
+++ b/docs/security.md
@@ -23,7 +23,7 @@ flowchart TB
     subgraph trusted["User's Machine (Trusted)"]
         token["API Token<br/>(env var)"]
         sshkeys["SSH Keys<br/>(filesystem)<br/>0600 perms"]
-        state[("Local State<br/>~/.config/spuff/state.db")]
+        state[("Local State<br/>~/.spuff/state.db")]
     end
 
     subgraph semitrust["Cloud VM (Semi-trusted)"]
@@ -176,8 +176,8 @@ users:
 
 | Data | Storage | Protection |
 |------|---------|------------|
-| Config | ~/.config/spuff/config.yaml | 0600 permissions |
-| State | ~/.config/spuff/state.db | Standard file perms |
+| Config | ~/.spuff/config.yaml | 0600 permissions |
+| State | ~/.spuff/state.db | Standard file perms |
 | SSH keys | ~/.ssh/ | 0600 permissions |
 
 #### In Transit

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -42,36 +42,33 @@ A **Spuff configuration** consists of:
 
 The following diagram shows how the configuration elements interact:
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                        spuff.yaml                               │
-├─────────────────────────────────────────────────────────────────┤
-│  version: "1"                                                   │
-│  name: my-project                                               │
-│                                                                 │
-│  ┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐  │
-│  │    resources    │  │     bundles     │  │    packages     │  │
-│  │  (VM sizing)    │  │  (toolchains)   │  │  (apt install)  │  │
-│  └────────┬────────┘  └────────┬────────┘  └────────┬────────┘  │
-│           │                    │                    │           │
-│           ▼                    ▼                    ▼           │
-│  ┌─────────────────────────────────────────────────────────────┐│
-│  │                    Cloud-Init Bootstrap                     ││
-│  └─────────────────────────────────────────────────────────────┘│
-│                                │                                │
-│                                ▼                                │
-│  ┌─────────────────────────────────────────────────────────────┐│
-│  │                      spuff-agent                            ││
-│  │  ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐           ││
-│  │  │services │ │  repos  │ │  setup  │ │  hooks  │           ││
-│  │  │(docker) │ │  (git)  │ │(scripts)│ │(post_up)│           ││
-│  │  └─────────┘ └─────────┘ └─────────┘ └─────────┘           ││
-│  └─────────────────────────────────────────────────────────────┘│
-│                                                                 │
-│  ┌─────────────────────────────────────────────────────────────┐│
-│  │  ports: [3000, 8080]  →  SSH Tunnel (spuff ssh)             ││
-│  └─────────────────────────────────────────────────────────────┘│
-└─────────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TB
+    subgraph spuffyaml["spuff.yaml"]
+        version["version: '1'<br/>name: my-project"]
+
+        subgraph config["Configuration"]
+            resources["resources<br/>(VM sizing)"]
+            bundles["bundles<br/>(toolchains)"]
+            packages["packages<br/>(apt install)"]
+        end
+
+        cloudinit["Cloud-Init Bootstrap"]
+
+        subgraph agent["spuff-agent"]
+            services["services<br/>(docker)"]
+            repos["repos<br/>(git)"]
+            setup["setup<br/>(scripts)"]
+            hooks["hooks<br/>(post_up)"]
+        end
+
+        ports["ports: [3000, 8080] → SSH Tunnel (spuff ssh)"]
+    end
+
+    resources --> cloudinit
+    bundles --> cloudinit
+    packages --> cloudinit
+    cloudinit --> agent
 ```
 
 ### File Discovery

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -154,7 +154,7 @@ Configuration values follow this precedence order (highest to lowest):
 
 1. CLI flags (`--size`, `--region`)
 2. Project configuration (`spuff.yaml`)
-3. Global configuration (`~/.config/spuff/config.yaml`)
+3. Global configuration (`~/.spuff/config.yaml`)
 4. Provider defaults
 
 ### size

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -15,7 +15,7 @@ spuff status
 RUST_LOG=debug spuff status
 
 # Check local state
-sqlite3 ~/.config/spuff/state.db "SELECT * FROM instances;"
+sqlite3 ~/.spuff/state.db "SELECT * FROM instances;"
 ```
 
 ---
@@ -329,7 +329,7 @@ Error: No active instance found
 **Diagnosis:**
 ```bash
 # Check local state
-sqlite3 ~/.config/spuff/state.db "SELECT * FROM instances;"
+sqlite3 ~/.spuff/state.db "SELECT * FROM instances;"
 
 # Check provider for spuff instances
 curl -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
@@ -345,7 +345,7 @@ curl -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
 2. **Instance was deleted externally**
    ```bash
    # Clear local state
-   rm ~/.config/spuff/state.db
+   rm ~/.spuff/state.db
    ```
 
 ### State out of sync
@@ -357,7 +357,7 @@ curl -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
 **Solution:**
 ```bash
 # Reset local state
-rm ~/.config/spuff/state.db
+rm ~/.spuff/state.db
 
 # Recreate
 spuff up
@@ -449,7 +449,7 @@ Error: Request failed: connection refused
 
 **Symptoms:**
 ```
-Error: Config file not found at ~/.config/spuff/config.yaml
+Error: Config file not found at ~/.spuff/config.yaml
 ```
 
 **Solution:**
@@ -467,10 +467,10 @@ Error: Invalid config: missing field 'region'
 **Solution:**
 ```bash
 # View current config
-cat ~/.config/spuff/config.yaml
+cat ~/.spuff/config.yaml
 
 # Recreate
-rm ~/.config/spuff/config.yaml
+rm ~/.spuff/config.yaml
 spuff init
 ```
 
@@ -511,7 +511,7 @@ spuff status --detailed
 spuff config show
 
 # Reset state
-rm ~/.config/spuff/state.db
+rm ~/.spuff/state.db
 
 # Reset terminal
 reset

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,7 +17,7 @@ This directory contains example configurations and templates for spuff.
 Copy an example to your config directory:
 
 ```bash
-cp examples/configs/developer.yaml ~/.config/spuff/config.yaml
+cp examples/configs/developer.yaml ~/.spuff/config.yaml
 ```
 
 Or use as a reference when running `spuff init`.

--- a/src/agent/main.rs
+++ b/src/agent/main.rs
@@ -27,6 +27,7 @@ mod devtools;
 mod metrics;
 mod project_setup;
 mod routes;
+mod volume_manager;
 
 use std::collections::VecDeque;
 use std::net::SocketAddr;

--- a/src/agent/volume_manager.rs
+++ b/src/agent/volume_manager.rs
@@ -1,0 +1,225 @@
+//! Volume management for the spuff-agent.
+//!
+//! Provides functionality to list, monitor, and manage SSHFS mounts on the VM.
+//! This is a simplified implementation for the agent side - the full VolumeManager
+//! with driver abstraction lives in the CLI.
+
+use serde::{Deserialize, Serialize};
+use std::process::Stdio;
+use std::time::Instant;
+use tokio::process::Command;
+
+/// Information about a mounted volume
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MountInfo {
+    /// Mount source (e.g., user@localhost:/path)
+    pub source: String,
+    /// Mount target path on this VM
+    pub target: String,
+    /// Filesystem type (e.g., fuse.sshfs)
+    pub fs_type: String,
+    /// Mount options
+    pub options: Vec<String>,
+}
+
+/// Status of a volume mount
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VolumeStatus {
+    /// Mount information
+    pub mount: MountInfo,
+    /// Whether the mount is currently accessible
+    pub accessible: bool,
+    /// Latency in milliseconds to access the mount (if accessible)
+    pub latency_ms: Option<u64>,
+    /// Error message if not accessible
+    pub error: Option<String>,
+}
+
+/// Agent-side volume manager
+///
+/// Manages volume mounts on the remote VM. This is a simplified implementation
+/// that interacts with the local filesystem and mount commands.
+pub struct AgentVolumeManager;
+
+impl AgentVolumeManager {
+    /// Create a new agent volume manager
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// List all SSHFS mounts on this VM
+    pub async fn list_mounts(&self) -> Vec<MountInfo> {
+        self.parse_mounts()
+            .await
+            .into_iter()
+            .filter(|m| m.fs_type == "fuse.sshfs")
+            .collect()
+    }
+
+    /// Get detailed status of all SSHFS mounts
+    pub async fn get_status(&self) -> Vec<VolumeStatus> {
+        let mounts = self.list_mounts().await;
+        let mut statuses = Vec::with_capacity(mounts.len());
+
+        for mount in mounts {
+            let status = self.check_mount_status(&mount).await;
+            statuses.push(status);
+        }
+
+        statuses
+    }
+
+    /// Check if a specific target is mounted
+    pub async fn is_mounted(&self, target: &str) -> bool {
+        let mounts = self.list_mounts().await;
+        mounts.iter().any(|m| m.target == target)
+    }
+
+    /// Unmount a volume
+    pub async fn unmount(&self, target: &str) -> Result<(), String> {
+        if !self.is_mounted(target).await {
+            return Err(format!("Mount not found: {}", target));
+        }
+
+        // Try fusermount first, then regular umount
+        let output = Command::new("fusermount")
+            .args(["-u", target])
+            .output()
+            .await;
+
+        match output {
+            Ok(o) if o.status.success() => {
+                tracing::info!("Successfully unmounted {} with fusermount", target);
+                Ok(())
+            }
+            _ => {
+                // Fallback to sudo umount
+                let output = Command::new("sudo")
+                    .args(["umount", target])
+                    .output()
+                    .await
+                    .map_err(|e| format!("Failed to execute umount: {}", e))?;
+
+                if output.status.success() {
+                    tracing::info!("Successfully unmounted {} with sudo umount", target);
+                    Ok(())
+                } else {
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    Err(format!("Failed to unmount: {}", stderr.trim()))
+                }
+            }
+        }
+    }
+
+    /// Parse /proc/mounts to get mount information
+    async fn parse_mounts(&self) -> Vec<MountInfo> {
+        let content = match tokio::fs::read_to_string("/proc/mounts").await {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!("Failed to read /proc/mounts: {}", e);
+                return Vec::new();
+            }
+        };
+
+        content
+            .lines()
+            .filter_map(|line| {
+                let parts: Vec<&str> = line.split_whitespace().collect();
+                if parts.len() >= 4 {
+                    Some(MountInfo {
+                        source: parts[0].to_string(),
+                        target: parts[1].to_string(),
+                        fs_type: parts[2].to_string(),
+                        options: parts[3].split(',').map(String::from).collect(),
+                    })
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    /// Check the status of a mount
+    async fn check_mount_status(&self, mount: &MountInfo) -> VolumeStatus {
+        let start = Instant::now();
+
+        // Try to stat the mount point to check accessibility
+        let result = Command::new("stat")
+            .arg(&mount.target)
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .output()
+            .await;
+
+        let latency_ms = start.elapsed().as_millis() as u64;
+
+        match result {
+            Ok(output) if output.status.success() => VolumeStatus {
+                mount: mount.clone(),
+                accessible: true,
+                latency_ms: Some(latency_ms),
+                error: None,
+            },
+            Ok(output) => {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                VolumeStatus {
+                    mount: mount.clone(),
+                    accessible: false,
+                    latency_ms: None,
+                    error: Some(stderr.trim().to_string()),
+                }
+            }
+            Err(e) => VolumeStatus {
+                mount: mount.clone(),
+                accessible: false,
+                latency_ms: None,
+                error: Some(format!("Failed to check status: {}", e)),
+            },
+        }
+    }
+}
+
+impl Default for AgentVolumeManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mount_info_serialization() {
+        let info = MountInfo {
+            source: "user@localhost:/home/user/project".to_string(),
+            target: "/mnt/project".to_string(),
+            fs_type: "fuse.sshfs".to_string(),
+            options: vec!["rw".to_string(), "user_id=1000".to_string()],
+        };
+
+        let json = serde_json::to_string(&info).unwrap();
+        assert!(json.contains("user@localhost"));
+        assert!(json.contains("/mnt/project"));
+        assert!(json.contains("fuse.sshfs"));
+    }
+
+    #[test]
+    fn test_volume_status_serialization() {
+        let status = VolumeStatus {
+            mount: MountInfo {
+                source: "user@localhost:/path".to_string(),
+                target: "/mnt/test".to_string(),
+                fs_type: "fuse.sshfs".to_string(),
+                options: vec!["rw".to_string()],
+            },
+            accessible: true,
+            latency_ms: Some(25),
+            error: None,
+        };
+
+        let json = serde_json::to_string(&status).unwrap();
+        assert!(json.contains("\"accessible\":true"));
+        assert!(json.contains("\"latency_ms\":25"));
+    }
+}

--- a/src/cli/commands/down.rs
+++ b/src/cli/commands/down.rs
@@ -3,9 +3,11 @@ use dialoguer::Confirm;
 
 use crate::config::AppConfig;
 use crate::error::{Result, SpuffError};
+use crate::project_config::ProjectConfig;
 use crate::provider::create_provider;
 use crate::state::StateDb;
 use crate::utils::format_elapsed;
+use crate::volume::{SshfsLocalCommands, VolumeState};
 
 pub async fn execute(config: &AppConfig, create_snapshot: bool, force: bool) -> Result<()> {
     let db = StateDb::open()?;
@@ -48,6 +50,60 @@ pub async fn execute(config: &AppConfig, create_snapshot: bool, force: bool) -> 
             println!("  {}", style("Cancelled.").dim());
             return Ok(());
         }
+    }
+
+    // Unmount any locally mounted volumes BEFORE destroying the instance
+    // This prevents SSHFS from hanging when the remote server disappears
+    let project_config = ProjectConfig::load_from_cwd().ok().flatten();
+    let mut volume_state = VolumeState::load().unwrap_or_default();
+
+    // Collect all mount points to unmount
+    let mut mount_points_to_unmount: Vec<String> = Vec::new();
+
+    // Add mounts from project config
+    if let Some(ref pc) = project_config {
+        for vol in &pc.volumes {
+            let mount_point = vol.resolve_mount_point(Some(&instance.name), pc.base_dir.as_deref());
+            if !mount_points_to_unmount.contains(&mount_point) {
+                mount_points_to_unmount.push(mount_point);
+            }
+        }
+    }
+
+    // Add tracked mounts from state
+    for m in &volume_state.mounts {
+        if !mount_points_to_unmount.contains(&m.mount_point) {
+            mount_points_to_unmount.push(m.mount_point.clone());
+        }
+    }
+
+    if !mount_points_to_unmount.is_empty() {
+        println!();
+        println!(
+            "  {} {}",
+            style("◐").cyan(),
+            style("Unmounting local volumes...").dim()
+        );
+
+        for mount_point in &mount_points_to_unmount {
+            print!("    {} {}", style("→").dim(), style(&mount_point).white());
+
+            match SshfsLocalCommands::unmount(mount_point).await {
+                Ok(_) => {
+                    println!(" {}", style("✓").green());
+                    volume_state.remove_mount(mount_point);
+                }
+                Err(e) => {
+                    println!(" {}", style("✕").red());
+                    tracing::warn!("Failed to unmount {}: {}", mount_point, e);
+                    // Continue with other unmounts even if one fails
+                }
+            }
+        }
+
+        // Clear volume state
+        volume_state.clear();
+        volume_state.save().ok();
     }
 
     let provider = create_provider(config)?;

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -80,6 +80,7 @@ pub async fn execute() -> Result<()> {
         tailscale_authkey: None,
         agent_token: None, // Can be set via SPUFF_AGENT_TOKEN env var
         ai_tools: None,    // None means use default (all)
+        volumes: Vec::new(),
     };
 
     config.save()?;

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -8,3 +8,4 @@ pub mod snapshot;
 pub mod ssh;
 pub mod status;
 pub mod up;
+pub mod volume;

--- a/src/cli/commands/volume.rs
+++ b/src/cli/commands/volume.rs
@@ -1,0 +1,580 @@
+//! Volume management commands
+//!
+//! Commands for mounting and managing volumes.
+//! Mounts remote VM directories locally using SSHFS.
+
+use console::style;
+
+use crate::config::AppConfig;
+use crate::error::{Result, SpuffError};
+use crate::project_config::ProjectConfig;
+use crate::state::StateDb;
+use crate::volume::{
+    get_install_instructions, SshfsDriver, SshfsLocalCommands, VolumeConfig, VolumeState,
+};
+
+/// List configured and mounted volumes
+pub async fn list(_config: &AppConfig) -> Result<()> {
+    let db = StateDb::open()?;
+    let instance = db
+        .get_active_instance()?
+        .ok_or(SpuffError::NoActiveInstance)?;
+
+    println!();
+    println!(
+        "  {} {}",
+        style("Volumes for").dim(),
+        style(&instance.name).cyan()
+    );
+    println!();
+
+    // Get volumes from project config
+    let project_config = ProjectConfig::load_from_cwd().ok().flatten();
+
+    // Get current mount state
+    let volume_state = VolumeState::load().unwrap_or_default();
+
+    match project_config {
+        Some(pc) if !pc.volumes.is_empty() => {
+            println!(
+                "  {:<30} {:<30} {}",
+                style("Remote Path").bold(),
+                style("Local Mount").bold(),
+                style("Status").bold()
+            );
+            println!("  {}", style("─".repeat(75)).dim());
+
+            for vol in &pc.volumes {
+                let mount_point =
+                    vol.resolve_mount_point(Some(&instance.name), pc.base_dir.as_deref());
+                let is_mounted = SshfsLocalCommands::is_mounted(&mount_point).await;
+
+                let status = if is_mounted {
+                    style("● mounted").green()
+                } else {
+                    style("○ not mounted").dim()
+                };
+
+                let options = if vol.read_only { " (ro)" } else { "" };
+
+                println!(
+                    "  {:<30} {:<30} {}{}",
+                    truncate(&vol.target, 28),
+                    truncate(&mount_point, 28),
+                    status,
+                    options
+                );
+            }
+
+            println!();
+            println!(
+                "  {} {} configured volume(s)",
+                style("•").cyan(),
+                pc.volumes.len()
+            );
+
+            let mounted_count = volume_state.mounts.len();
+            if mounted_count > 0 {
+                println!(
+                    "  {} {} currently mounted",
+                    style("•").green(),
+                    mounted_count
+                );
+            }
+        }
+        _ => {
+            println!("  {}", style("No volumes configured in spuff.yaml").dim());
+            println!();
+            println!("  Add volumes to your spuff.yaml:");
+            println!();
+            println!("  {}", style("volumes:").cyan());
+            println!(
+                "    {}  {}",
+                style("-").dim(),
+                style("target: /home/dev/project").white()
+            );
+            println!(
+                "      {}  {}",
+                style("mount_point:").dim(),
+                style("~/mnt/project").white()
+            );
+        }
+    }
+
+    println!();
+    Ok(())
+}
+
+/// Show detailed status of volumes
+pub async fn status(_config: &AppConfig) -> Result<()> {
+    let db = StateDb::open()?;
+    let instance = db
+        .get_active_instance()?
+        .ok_or(SpuffError::NoActiveInstance)?;
+
+    let project_config = ProjectConfig::load_from_cwd().ok().flatten();
+
+    println!();
+    println!(
+        "  {} {}",
+        style("Volume Status for").dim(),
+        style(&instance.name).cyan()
+    );
+    println!();
+
+    // Check SSHFS availability
+    let sshfs_available = SshfsDriver::check_sshfs_installed().await;
+    let fuse_available = SshfsDriver::check_fuse_available().await;
+
+    if !sshfs_available || !fuse_available {
+        println!("  {} SSHFS not available", style("⚠").yellow().bold());
+        println!();
+        println!("{}", get_install_instructions());
+        println!();
+        return Ok(());
+    }
+
+    println!("  {} SSHFS installed and ready", style("✓").green().bold());
+    println!();
+
+    match project_config {
+        Some(pc) if !pc.volumes.is_empty() => {
+            for vol in &pc.volumes {
+                let mount_point =
+                    vol.resolve_mount_point(Some(&instance.name), pc.base_dir.as_deref());
+                let mount_status = SshfsLocalCommands::check_status(&mount_point).await?;
+
+                let status_icon = if mount_status.mounted && mount_status.healthy {
+                    style("●").green()
+                } else if mount_status.mounted {
+                    style("●").yellow()
+                } else {
+                    style("○").red()
+                };
+
+                let status_text = if mount_status.mounted && mount_status.healthy {
+                    style("healthy").green()
+                } else if mount_status.mounted {
+                    style("degraded").yellow()
+                } else {
+                    style("not mounted").red()
+                };
+
+                println!(
+                    "  {} VM:{} → {}",
+                    status_icon,
+                    style(&vol.target).cyan(),
+                    style(&mount_point).white()
+                );
+                println!(
+                    "    {} {}{}",
+                    style("Status:").dim(),
+                    status_text,
+                    mount_status
+                        .latency_ms
+                        .map(|l| format!(" ({}ms)", l))
+                        .unwrap_or_default()
+                );
+
+                if vol.read_only {
+                    println!("    {} read-only", style("Mode:").dim());
+                }
+
+                if let Some(ref err) = mount_status.error {
+                    println!("    {} {}", style("Error:").red(), err);
+                }
+
+                println!();
+            }
+        }
+        _ => {
+            println!("  {}", style("No volumes configured").dim());
+        }
+    }
+
+    Ok(())
+}
+
+/// Mount a volume (ad-hoc or from config)
+pub async fn mount(config: &AppConfig, spec: Option<&str>) -> Result<()> {
+    let db = StateDb::open()?;
+    let instance = db
+        .get_active_instance()?
+        .ok_or(SpuffError::NoActiveInstance)?;
+
+    // Check SSHFS availability
+    if !SshfsDriver::check_sshfs_installed().await {
+        println!();
+        println!("{}", get_install_instructions());
+        println!();
+        return Err(SpuffError::Volume("SSHFS not installed".to_string()));
+    }
+
+    if !SshfsDriver::check_fuse_available().await {
+        println!();
+        println!("{}", get_install_instructions());
+        println!();
+        return Err(SpuffError::Volume("FUSE not available".to_string()));
+    }
+
+    let ssh_key_path = crate::ssh::managed_key::get_managed_key_path()
+        .unwrap_or_else(|_| std::path::PathBuf::from(&config.ssh_key_path));
+
+    let ssh_key_str = ssh_key_path.to_string_lossy().to_string();
+
+    println!();
+
+    match spec {
+        Some(volume_spec) => {
+            // Mount ad-hoc volume (no project base dir for ad-hoc)
+            let volume_config = VolumeConfig::from_spec(volume_spec).map_err(SpuffError::Volume)?;
+            mount_single_volume(
+                &instance.ip,
+                &config.ssh_user,
+                &ssh_key_str,
+                &volume_config,
+                Some(&instance.name),
+                None,
+            )
+            .await?;
+        }
+        None => {
+            // Mount all volumes from project config
+            let project_config = ProjectConfig::load_from_cwd().ok().flatten();
+
+            match project_config {
+                Some(pc) if !pc.volumes.is_empty() => {
+                    println!(
+                        "  {} {} volume(s)...",
+                        style("Mounting").cyan(),
+                        pc.volumes.len()
+                    );
+                    println!();
+
+                    for vol in &pc.volumes {
+                        match mount_single_volume(
+                            &instance.ip,
+                            &config.ssh_user,
+                            &ssh_key_str,
+                            vol,
+                            Some(&instance.name),
+                            pc.base_dir.as_deref(),
+                        )
+                        .await
+                        {
+                            Ok(_) => {}
+                            Err(e) => {
+                                println!("  {} {} - {}", style("✕").red().bold(), vol.target, e);
+                            }
+                        }
+                    }
+                }
+                _ => {
+                    println!("  {}", style("No volumes configured in spuff.yaml").dim());
+                    println!();
+                    println!("  Mount a volume ad-hoc:");
+                    println!(
+                        "    {}",
+                        style("spuff volume mount /home/dev/project:~/mnt/project").cyan()
+                    );
+                }
+            }
+        }
+    }
+
+    println!();
+    Ok(())
+}
+
+/// Mount a single volume
+async fn mount_single_volume(
+    vm_ip: &str,
+    ssh_user: &str,
+    ssh_key_path: &str,
+    volume: &VolumeConfig,
+    instance_name: Option<&str>,
+    project_base_dir: Option<&std::path::Path>,
+) -> Result<()> {
+    let mount_point = volume.resolve_mount_point(instance_name, project_base_dir);
+    let source_path = volume.resolve_source(project_base_dir);
+
+    // Check if already mounted
+    if SshfsLocalCommands::is_mounted(&mount_point).await {
+        println!(
+            "  {} {} (already mounted)",
+            style("✓").green().bold(),
+            mount_point
+        );
+        return Ok(());
+    }
+
+    // If source is defined, sync local files to VM first
+    if !source_path.is_empty() && std::path::Path::new(&source_path).exists() {
+        println!(
+            "  {} {} → VM:{}",
+            style("Syncing").cyan(),
+            style(&source_path).white(),
+            style(&volume.target).green()
+        );
+
+        sync_to_vm(vm_ip, ssh_user, ssh_key_path, &source_path, &volume.target).await?;
+    }
+
+    println!(
+        "  {} VM:{} → {}",
+        style("Mounting").cyan(),
+        style(&volume.target).white(),
+        style(&mount_point).green()
+    );
+
+    // Execute the mount
+    SshfsLocalCommands::mount(
+        vm_ip,
+        ssh_user,
+        ssh_key_path,
+        &volume.target,
+        &mount_point,
+        volume.read_only,
+        &volume.options,
+    )
+    .await?;
+
+    // Save to state
+    let mut state = VolumeState::load().unwrap_or_default();
+    let handle = crate::volume::MountHandle::new("sshfs", &volume.target, &mount_point)
+        .with_vm_info(vm_ip, ssh_user)
+        .with_source(&source_path)
+        .with_read_only(volume.read_only);
+    state.add_mount(handle);
+    state.save().ok();
+
+    println!("  {} {}", style("✓").green().bold(), mount_point);
+
+    Ok(())
+}
+
+/// Sync local directory to VM using rsync
+async fn sync_to_vm(
+    vm_ip: &str,
+    ssh_user: &str,
+    ssh_key_path: &str,
+    local_path: &str,
+    remote_path: &str,
+) -> Result<()> {
+    use tokio::process::Command;
+
+    // Build rsync command
+    // rsync -avz --delete -e "ssh -i key -o StrictHostKeyChecking=no" local/ user@ip:remote/
+    let ssh_cmd = format!(
+        "ssh -i \"{}\" -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null",
+        ssh_key_path
+    );
+
+    // Ensure local path ends with / to sync contents, not the directory itself
+    let local_source = if local_path.ends_with('/') {
+        local_path.to_string()
+    } else {
+        format!("{}/", local_path)
+    };
+
+    let remote_dest = format!("{}@{}:{}", ssh_user, vm_ip, remote_path);
+
+    let output = Command::new("rsync")
+        .args([
+            "-avz",
+            "--delete",
+            "-e",
+            &ssh_cmd,
+            &local_source,
+            &remote_dest,
+        ])
+        .output()
+        .await
+        .map_err(|e| SpuffError::Volume(format!("Failed to execute rsync: {}", e)))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(SpuffError::Volume(format!(
+            "Failed to sync to VM: {}",
+            stderr
+        )));
+    }
+
+    tracing::info!("Synced {} to {}:{}", local_path, vm_ip, remote_path);
+    Ok(())
+}
+
+/// Unmount a volume or all volumes
+pub async fn unmount(_config: &AppConfig, target: Option<String>, all: bool) -> Result<()> {
+    let db = StateDb::open()?;
+    let instance = db
+        .get_active_instance()?
+        .ok_or(SpuffError::NoActiveInstance)?;
+
+    println!();
+
+    let mut state = VolumeState::load().unwrap_or_default();
+
+    if all {
+        println!("  {} all volumes...", style("Unmounting").cyan());
+
+        let project_config = ProjectConfig::load_from_cwd().ok().flatten();
+        if let Some(pc) = project_config {
+            for vol in &pc.volumes {
+                let mount_point =
+                    vol.resolve_mount_point(Some(&instance.name), pc.base_dir.as_deref());
+                match SshfsLocalCommands::unmount(&mount_point).await {
+                    Ok(_) => {
+                        state.remove_mount(&mount_point);
+                        println!("  {} {}", style("✓").green().bold(), mount_point);
+                    }
+                    Err(e) => {
+                        println!("  {} {} - {}", style("✕").red().bold(), mount_point, e);
+                    }
+                }
+            }
+        }
+
+        // Also unmount any tracked mounts not in config
+        let mount_points: Vec<String> =
+            state.mounts.iter().map(|m| m.mount_point.clone()).collect();
+        for mp in mount_points {
+            match SshfsLocalCommands::unmount(&mp).await {
+                Ok(_) => {
+                    state.remove_mount(&mp);
+                    println!("  {} {}", style("✓").green().bold(), mp);
+                }
+                Err(e) => {
+                    println!("  {} {} - {}", style("✕").red().bold(), mp, e);
+                }
+            }
+        }
+    } else if let Some(target_path) = target {
+        println!(
+            "  {} {}",
+            style("Unmounting").cyan(),
+            style(&target_path).white()
+        );
+
+        // Try to find the mount point - could be target (remote path) or mount_point (local path)
+        let mount_point = if let Some(handle) = state.find_mount(&target_path) {
+            handle.mount_point.clone()
+        } else {
+            // Assume it's the local path
+            target_path.clone()
+        };
+
+        SshfsLocalCommands::unmount(&mount_point).await?;
+        state.remove_mount(&target_path);
+
+        println!("  {} Volume unmounted", style("✓").green().bold());
+    } else {
+        println!(
+            "  {} Specify a target path or use --all",
+            style("!").yellow().bold()
+        );
+        return Ok(());
+    }
+
+    state.save().ok();
+    println!();
+    Ok(())
+}
+
+/// Remount volumes (useful after connection issues)
+pub async fn remount(config: &AppConfig, target: Option<String>) -> Result<()> {
+    let db = StateDb::open()?;
+    let instance = db
+        .get_active_instance()?
+        .ok_or(SpuffError::NoActiveInstance)?;
+
+    let project_config = ProjectConfig::load_from_cwd().ok().flatten();
+
+    let ssh_key_path = crate::ssh::managed_key::get_managed_key_path()
+        .unwrap_or_else(|_| std::path::PathBuf::from(&config.ssh_key_path));
+
+    let ssh_key_str = ssh_key_path.to_string_lossy().to_string();
+
+    println!();
+
+    match (target, project_config) {
+        (Some(target_path), Some(pc)) => {
+            // Remount specific volume
+            if let Some(vol) = pc.volumes.iter().find(|v| v.target == target_path) {
+                let mount_point =
+                    vol.resolve_mount_point(Some(&instance.name), pc.base_dir.as_deref());
+
+                println!(
+                    "  {} {}",
+                    style("Remounting").cyan(),
+                    style(&target_path).white()
+                );
+
+                // Unmount first
+                SshfsLocalCommands::unmount(&mount_point).await.ok();
+
+                // Mount again
+                mount_single_volume(
+                    &instance.ip,
+                    &config.ssh_user,
+                    &ssh_key_str,
+                    vol,
+                    Some(&instance.name),
+                    pc.base_dir.as_deref(),
+                )
+                .await?;
+
+                println!("  {} Volume remounted", style("✓").green().bold());
+            } else {
+                return Err(SpuffError::Volume(format!(
+                    "Volume not found in config: {}",
+                    target_path
+                )));
+            }
+        }
+        (None, Some(pc)) if !pc.volumes.is_empty() => {
+            // Remount all volumes
+            println!("  {} all volumes...", style("Remounting").cyan());
+
+            for vol in &pc.volumes {
+                let mount_point =
+                    vol.resolve_mount_point(Some(&instance.name), pc.base_dir.as_deref());
+
+                // Unmount first
+                SshfsLocalCommands::unmount(&mount_point).await.ok();
+
+                // Mount again
+                match mount_single_volume(
+                    &instance.ip,
+                    &config.ssh_user,
+                    &ssh_key_str,
+                    vol,
+                    Some(&instance.name),
+                    pc.base_dir.as_deref(),
+                )
+                .await
+                {
+                    Ok(_) => {}
+                    Err(e) => {
+                        println!("  {} {} - {}", style("✕").red().bold(), vol.target, e);
+                    }
+                }
+            }
+        }
+        _ => {
+            println!("  {}", style("No volumes configured").dim());
+        }
+    }
+
+    println!();
+    Ok(())
+}
+
+// Helper function
+fn truncate(s: &str, max_len: usize) -> String {
+    if s.len() > max_len {
+        format!("{}…", &s[..max_len - 1])
+    } else {
+        s.to_string()
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -69,7 +69,7 @@ impl AppConfig {
     pub fn config_dir() -> Result<PathBuf> {
         let home = std::env::var("HOME")
             .map_err(|_| SpuffError::Config("HOME environment variable not set".to_string()))?;
-        Ok(PathBuf::from(home).join(".config").join("spuff"))
+        Ok(PathBuf::from(home).join(".spuff"))
     }
 
     pub fn config_path() -> Result<PathBuf> {
@@ -393,7 +393,7 @@ tailscale_authkey: tskey-xxx
     #[ignore]
     fn test_config_save_and_load() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let config_dir = temp_dir.path().join(".config").join("spuff");
+        let config_dir = temp_dir.path().join(".spuff");
         std::fs::create_dir_all(&config_dir).unwrap();
         let config_path = config_dir.join("config.yaml");
 
@@ -437,7 +437,7 @@ tailscale_authkey: tskey-xxx
     #[ignore]
     fn test_config_load_with_env_token() {
         let temp_dir = tempfile::tempdir().unwrap();
-        let config_dir = temp_dir.path().join(".config").join("spuff");
+        let config_dir = temp_dir.path().join(".spuff");
         std::fs::create_dir_all(&config_dir).unwrap();
         let config_path = config_dir.join("config.yaml");
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::error::{Result, SpuffError};
 use crate::project_config::AiToolsConfig;
 use crate::provider::ProviderType;
+use crate::volume::VolumeConfig;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppConfig {
@@ -33,6 +34,10 @@ pub struct AppConfig {
     /// This is the user's default preference, can be overridden by project config or CLI.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ai_tools: Option<AiToolsConfig>,
+    /// Global volume mounts that apply to all instances.
+    /// These are merged with project-specific volumes from spuff.yaml.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub volumes: Vec<VolumeConfig>,
 }
 
 fn default_ssh_user() -> String {
@@ -55,6 +60,7 @@ impl Default for AppConfig {
             tailscale_authkey: None,
             agent_token: None,
             ai_tools: None, // None means use default (all)
+            volumes: Vec::new(),
         }
     }
 }
@@ -315,6 +321,7 @@ mod tests {
             tailscale_authkey: None,
             agent_token: None,
             ai_tools: None,
+            volumes: Vec::new(),
         };
 
         let yaml = serde_yaml::to_string(&config).unwrap();
@@ -327,6 +334,8 @@ mod tests {
         assert!(!yaml.contains("agent_token"));
         // ai_tools should not appear when None
         assert!(!yaml.contains("ai_tools"));
+        // volumes should not appear when empty
+        assert!(!yaml.contains("volumes"));
     }
 
     #[test]
@@ -408,6 +417,7 @@ tailscale_authkey: tskey-xxx
             tailscale_authkey: None,
             agent_token: None,
             ai_tools: None,
+            volumes: Vec::new(),
         };
 
         config.save().unwrap();

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,6 +45,9 @@ pub enum SpuffError {
     #[error("Dialog error: {0}")]
     Dialog(#[from] dialoguer::Error),
 
+    #[error("Volume error: {0}")]
+    Volume(String),
+
     #[error("SSH protocol error: {0}")]
     SshProtocol(#[from] russh::Error),
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod ssh;
 mod state;
 mod tui;
 pub mod utils;
+pub mod volume;
 
 use clap::Parser;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};

--- a/src/ssh/managed_key.rs
+++ b/src/ssh/managed_key.rs
@@ -3,7 +3,7 @@
 //! This module handles a spuff-managed ed25519 SSH key that avoids the RSA SHA2
 //! authentication issues with older russh versions.
 //!
-//! The key is stored at `~/.config/spuff/ssh_key` and is created automatically
+//! The key is stored at `~/.spuff/ssh_key` and is created automatically
 //! if it doesn't exist.
 
 use std::path::PathBuf;
@@ -15,10 +15,10 @@ use crate::error::{Result, SpuffError};
 
 /// Get the path to the spuff managed SSH key.
 pub fn get_managed_key_path() -> Result<PathBuf> {
-    let config_dir = dirs::config_dir()
-        .ok_or_else(|| SpuffError::Ssh("Cannot determine config directory".to_string()))?;
+    let home = std::env::var("HOME")
+        .map_err(|_| SpuffError::Ssh("HOME environment variable not set".to_string()))?;
 
-    Ok(config_dir.join("spuff").join("ssh_key"))
+    Ok(PathBuf::from(home).join(".spuff").join("ssh_key"))
 }
 
 /// Check if the managed key exists.
@@ -29,7 +29,7 @@ pub fn managed_key_exists() -> Result<bool> {
 
 /// Generate a new ed25519 SSH key for spuff.
 ///
-/// Creates the key at `~/.config/spuff/ssh_key` with no passphrase.
+/// Creates the key at `~/.spuff/ssh_key` with no passphrase.
 /// This key is used to authenticate with spuff-provisioned instances.
 pub fn generate_managed_key() -> Result<PathBuf> {
     let key_path = get_managed_key_path()?;

--- a/src/volume/config.rs
+++ b/src/volume/config.rs
@@ -1,0 +1,436 @@
+//! Volume configuration types for spuff.yaml
+//!
+//! Defines the configuration schema for volume mounts, supporting
+//! multiple drivers (SSHFS, NFS, etc.) with driver-specific options.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Volume mount configuration from spuff.yaml
+///
+/// The SSHFS driver mounts the remote VM directory locally, allowing
+/// local editors to work with files that live on the VM.
+///
+/// # Example
+/// ```yaml
+/// volumes:
+///   - source: ./src              # Local path (for initial sync, optional)
+///     target: /home/dev/project  # Path on the VM
+///     mount_point: ~/mnt/project # Where to mount locally (auto-generated if omitted)
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VolumeConfig {
+    /// Type of the volume driver (default: sshfs)
+    #[serde(default, rename = "type")]
+    pub driver_type: VolumeType,
+
+    /// Source path on the local machine (used for initial sync with rsync driver)
+    /// For sshfs-only usage, this can be omitted or set to same as mount_point
+    #[serde(default)]
+    pub source: String,
+
+    /// Target path on the remote VM where files will be accessible
+    pub target: String,
+
+    /// Local mount point where the VM directory will appear
+    /// If not specified, auto-generated under ~/.local/share/spuff/mounts/
+    #[serde(default)]
+    pub mount_point: Option<String>,
+
+    /// Mount as read-only
+    #[serde(default)]
+    pub read_only: bool,
+
+    /// Driver-specific options
+    #[serde(default)]
+    pub options: VolumeOptions,
+}
+
+/// Supported volume driver types
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, Hash)]
+#[serde(rename_all = "lowercase")]
+pub enum VolumeType {
+    /// SSHFS - SSH Filesystem (default)
+    #[default]
+    Sshfs,
+    // Future drivers:
+    // Nfs,
+    // NineP,
+}
+
+impl std::fmt::Display for VolumeType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VolumeType::Sshfs => write!(f, "sshfs"),
+        }
+    }
+}
+
+impl std::str::FromStr for VolumeType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "sshfs" => Ok(VolumeType::Sshfs),
+            _ => Err(format!("Unknown volume type: {}", s)),
+        }
+    }
+}
+
+/// Driver-specific mount options
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VolumeOptions {
+    /// Auto-reconnect on connection loss (default: true)
+    #[serde(default = "default_true")]
+    pub reconnect: bool,
+
+    /// Enable compression for data transfer
+    #[serde(default)]
+    pub compression: bool,
+
+    /// Enable caching for better performance (default: true)
+    #[serde(default = "default_true")]
+    pub cache: bool,
+
+    /// SSH keep-alive interval in seconds (default: 15)
+    #[serde(default = "default_server_alive_interval")]
+    pub server_alive_interval: u16,
+
+    /// Number of keep-alive messages before disconnect (default: 3)
+    #[serde(default = "default_server_alive_count_max")]
+    pub server_alive_count_max: u8,
+
+    /// Extra driver-specific options as key-value pairs
+    #[serde(default, flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn default_server_alive_interval() -> u16 {
+    15
+}
+
+fn default_server_alive_count_max() -> u8 {
+    3
+}
+
+impl Default for VolumeOptions {
+    fn default() -> Self {
+        Self {
+            reconnect: default_true(),
+            compression: false,
+            cache: default_true(),
+            server_alive_interval: default_server_alive_interval(),
+            server_alive_count_max: default_server_alive_count_max(),
+            extra: HashMap::new(),
+        }
+    }
+}
+
+/// Normalize a path by removing `.` and resolving `..` components
+/// Unlike `canonicalize`, this doesn't require the path to exist
+fn normalize_path(path: std::path::PathBuf) -> std::path::PathBuf {
+    use std::path::Component;
+
+    let mut components = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {} // Skip `.`
+            Component::ParentDir => {
+                // Go up one level if possible
+                if !components.is_empty() {
+                    components.pop();
+                }
+            }
+            c => components.push(c),
+        }
+    }
+
+    components.iter().collect()
+}
+
+impl VolumeConfig {
+    /// Create a new volume config with defaults
+    pub fn new(source: impl Into<String>, target: impl Into<String>) -> Self {
+        Self {
+            driver_type: VolumeType::default(),
+            source: source.into(),
+            target: target.into(),
+            mount_point: None,
+            read_only: false,
+            options: VolumeOptions::default(),
+        }
+    }
+
+    /// Parse a volume spec string in the format "source:target" or "source:target:ro"
+    /// For SSHFS: "remote_path:local_mount" or "remote_path:local_mount:ro"
+    pub fn from_spec(spec: &str) -> Result<Self, String> {
+        let parts: Vec<&str> = spec.split(':').collect();
+
+        match parts.as_slice() {
+            [target, mount_point] => {
+                let mut config = Self::new("", *target);
+                config.mount_point = Some((*mount_point).to_string());
+                Ok(config)
+            }
+            [target, mount_point, "ro"] => {
+                let mut config = Self::new("", *target);
+                config.mount_point = Some((*mount_point).to_string());
+                config.read_only = true;
+                Ok(config)
+            }
+            _ => Err(format!(
+                "Invalid volume spec '{}'. Expected format: 'remote_path:local_mount' or 'remote_path:local_mount:ro'",
+                spec
+            )),
+        }
+    }
+
+    /// Resolve the source path (expand ~ and relative paths)
+    ///
+    /// # Arguments
+    /// * `project_base_dir` - Base directory of the spuff.yaml file for resolving relative paths
+    pub fn resolve_source(&self, project_base_dir: Option<&std::path::Path>) -> String {
+        if self.source.is_empty() {
+            return String::new();
+        }
+
+        let expanded = shellexpand::tilde(&self.source).to_string();
+
+        // If relative, make it absolute from project base directory (where spuff.yaml is)
+        if !expanded.starts_with('/') {
+            let base = project_base_dir
+                .map(|p| p.to_path_buf())
+                .or_else(|| std::env::current_dir().ok())
+                .unwrap_or_else(|| std::path::PathBuf::from("."));
+            let joined = base.join(&expanded);
+            return normalize_path(joined).to_string_lossy().to_string();
+        }
+
+        expanded
+    }
+
+    /// Get the local mount point, generating one if not specified
+    ///
+    /// Priority:
+    /// 1. Explicit mount_point from config
+    /// 2. Use source path (mount over local dir for bidirectional editing)
+    /// 3. Auto-generate from target path name
+    ///
+    /// # Arguments
+    /// * `instance_name` - Instance name for unique mount point generation
+    /// * `project_base_dir` - Base directory of the spuff.yaml file for resolving relative paths
+    pub fn resolve_mount_point(
+        &self,
+        instance_name: Option<&str>,
+        project_base_dir: Option<&std::path::Path>,
+    ) -> String {
+        // 1. Explicit mount_point takes priority
+        if let Some(ref mp) = self.mount_point {
+            let expanded = shellexpand::tilde(mp).to_string();
+            if !expanded.starts_with('/') {
+                let base = project_base_dir
+                    .map(|p| p.to_path_buf())
+                    .or_else(|| std::env::current_dir().ok())
+                    .unwrap_or_else(|| std::path::PathBuf::from("."));
+                let joined = base.join(&expanded);
+                return normalize_path(joined).to_string_lossy().to_string();
+            }
+            return expanded;
+        }
+
+        // 2. If source is defined, use it as mount_point for bidirectional editing
+        // This mounts the VM directory over the local source folder
+        if !self.source.is_empty() {
+            return self.resolve_source(project_base_dir);
+        }
+
+        // 3. Auto-generate mount point from target path
+        let target_name = std::path::Path::new(&self.target)
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| "volume".to_string());
+
+        // Use ~/.local/share/spuff/mounts to avoid paths with spaces
+        // (macOS's Application Support has spaces which breaks SSHFS)
+        let base_dir = dirs::home_dir()
+            .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
+            .join(".local")
+            .join("share")
+            .join("spuff")
+            .join("mounts");
+
+        // Include instance name if provided for uniqueness
+        let mount_dir = if let Some(name) = instance_name {
+            base_dir.join(name).join(&target_name)
+        } else {
+            base_dir.join(&target_name)
+        };
+
+        mount_dir.to_string_lossy().to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_volume_type_default() {
+        assert_eq!(VolumeType::default(), VolumeType::Sshfs);
+    }
+
+    #[test]
+    fn test_volume_type_display() {
+        assert_eq!(VolumeType::Sshfs.to_string(), "sshfs");
+    }
+
+    #[test]
+    fn test_volume_type_from_str() {
+        assert_eq!("sshfs".parse::<VolumeType>().unwrap(), VolumeType::Sshfs);
+        assert_eq!("SSHFS".parse::<VolumeType>().unwrap(), VolumeType::Sshfs);
+        assert!("unknown".parse::<VolumeType>().is_err());
+    }
+
+    #[test]
+    fn test_volume_config_new() {
+        let config = VolumeConfig::new("./src", "/mnt/src");
+        assert_eq!(config.source, "./src");
+        assert_eq!(config.target, "/mnt/src");
+        assert_eq!(config.driver_type, VolumeType::Sshfs);
+        assert!(config.mount_point.is_none());
+        assert!(!config.read_only);
+    }
+
+    #[test]
+    fn test_volume_config_from_spec() {
+        // Format: remote_path:local_mount
+        let config = VolumeConfig::from_spec("/home/dev/project:~/mnt/project").unwrap();
+        assert_eq!(config.target, "/home/dev/project");
+        assert_eq!(config.mount_point, Some("~/mnt/project".to_string()));
+        assert!(!config.read_only);
+
+        let config = VolumeConfig::from_spec("/home/dev/project:~/mnt/project:ro").unwrap();
+        assert!(config.read_only);
+    }
+
+    #[test]
+    fn test_volume_config_from_spec_invalid() {
+        assert!(VolumeConfig::from_spec("invalid").is_err());
+        assert!(VolumeConfig::from_spec("a:b:c:d").is_err());
+    }
+
+    #[test]
+    fn test_resolve_mount_point_explicit() {
+        let mut config = VolumeConfig::new("", "/home/dev/project");
+        config.mount_point = Some("~/my-mount".to_string());
+
+        let resolved = config.resolve_mount_point(None, None);
+        assert!(resolved.contains("my-mount"));
+    }
+
+    #[test]
+    fn test_resolve_mount_point_auto_generated() {
+        let config = VolumeConfig::new("", "/home/dev/project");
+
+        let resolved = config.resolve_mount_point(Some("my-vm"), None);
+        assert!(resolved.contains("spuff"));
+        assert!(resolved.contains("mounts"));
+        assert!(resolved.contains("my-vm"));
+        assert!(resolved.contains("project"));
+    }
+
+    #[test]
+    fn test_resolve_mount_point_relative_with_base_dir() {
+        let mut config = VolumeConfig::new("./data", "/home/dev/data");
+        config.mount_point = Some("./mnt".to_string());
+
+        let base_dir = std::path::Path::new("/projects/myapp");
+        let resolved = config.resolve_mount_point(None, Some(base_dir));
+        // Path is joined but not normalized, starts with base_dir
+        assert!(resolved.starts_with("/projects/myapp"));
+        assert!(resolved.contains("mnt"));
+    }
+
+    #[test]
+    fn test_resolve_source_relative_with_base_dir() {
+        let config = VolumeConfig::new("./data", "/home/dev/data");
+
+        let base_dir = std::path::Path::new("/projects/myapp");
+        let resolved = config.resolve_source(Some(base_dir));
+        // Path is joined but not normalized, starts with base_dir
+        assert!(resolved.starts_with("/projects/myapp"));
+        assert!(resolved.contains("data"));
+    }
+
+    #[test]
+    fn test_resolve_mount_point_relative_without_dot() {
+        let mut config = VolumeConfig::new("data", "/home/dev/data");
+        config.mount_point = Some("mnt".to_string());
+
+        let base_dir = std::path::Path::new("/projects/myapp");
+        let resolved = config.resolve_mount_point(None, Some(base_dir));
+        assert_eq!(resolved, "/projects/myapp/mnt");
+    }
+
+    #[test]
+    fn test_resolve_source_relative_without_dot() {
+        let config = VolumeConfig::new("data", "/home/dev/data");
+
+        let base_dir = std::path::Path::new("/projects/myapp");
+        let resolved = config.resolve_source(Some(base_dir));
+        assert_eq!(resolved, "/projects/myapp/data");
+    }
+
+    #[test]
+    fn test_volume_options_defaults() {
+        let options = VolumeOptions::default();
+        assert!(options.reconnect);
+        assert!(!options.compression);
+        assert!(options.cache);
+        assert_eq!(options.server_alive_interval, 15);
+        assert_eq!(options.server_alive_count_max, 3);
+    }
+
+    #[test]
+    fn test_parse_yaml_volume() {
+        let yaml = r#"
+type: sshfs
+source: ./src
+target: /home/dev/project
+mount_point: ~/mnt/project
+read_only: true
+options:
+  compression: true
+  reconnect: true
+"#;
+
+        let config: VolumeConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.driver_type, VolumeType::Sshfs);
+        assert_eq!(config.source, "./src");
+        assert_eq!(config.target, "/home/dev/project");
+        assert_eq!(config.mount_point, Some("~/mnt/project".to_string()));
+        assert!(config.read_only);
+        assert!(config.options.compression);
+        assert!(config.options.reconnect);
+    }
+
+    #[test]
+    fn test_parse_yaml_volume_minimal() {
+        // Minimal config - just target (remote path)
+        let yaml = r#"
+target: /home/dev/project
+"#;
+
+        let config: VolumeConfig = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(config.driver_type, VolumeType::Sshfs);
+        assert_eq!(config.target, "/home/dev/project");
+        assert!(config.mount_point.is_none()); // Auto-generated at runtime
+        assert!(!config.read_only);
+        assert!(config.options.reconnect);
+    }
+}

--- a/src/volume/driver.rs
+++ b/src/volume/driver.rs
@@ -1,0 +1,119 @@
+//! Volume driver trait definition
+//!
+//! Defines the interface that all volume drivers must implement.
+
+use async_trait::async_trait;
+
+use crate::error::Result;
+
+use super::config::VolumeConfig;
+use super::state::{MountHandle, MountStatus};
+
+/// Trait that all volume drivers must implement
+///
+/// Volume drivers are responsible for mounting and unmounting
+/// volumes using their specific protocols (SSHFS, NFS, etc.).
+#[async_trait]
+pub trait VolumeDriver: Send + Sync {
+    /// Returns the driver name (e.g., "sshfs", "nfs")
+    fn name(&self) -> &'static str;
+
+    /// Returns a human-readable description of the driver
+    fn description(&self) -> &'static str;
+
+    /// Check if this driver is available on the system
+    ///
+    /// This checks for required binaries and dependencies.
+    async fn is_available(&self) -> bool;
+
+    /// Mount a volume according to the configuration
+    ///
+    /// # Arguments
+    /// * `config` - The volume configuration
+    /// * `tunnel_port` - Optional port for reverse SSH tunnel (used by SSHFS)
+    /// * `remote_user` - Username on the remote VM
+    ///
+    /// # Returns
+    /// A mount handle that can be used to manage the mount
+    async fn mount(
+        &self,
+        config: &VolumeConfig,
+        tunnel_port: Option<u16>,
+        remote_user: &str,
+    ) -> Result<MountHandle>;
+
+    /// Unmount a volume
+    ///
+    /// # Arguments
+    /// * `handle` - The mount handle returned from `mount()`
+    async fn unmount(&self, handle: &MountHandle) -> Result<()>;
+
+    /// Get the current status of a mount
+    ///
+    /// # Arguments
+    /// * `handle` - The mount handle to check
+    async fn status(&self, handle: &MountHandle) -> Result<MountStatus>;
+
+    /// Remount a volume (useful after connection issues)
+    ///
+    /// This is a convenience method that unmounts and remounts.
+    /// Drivers may override this with a more efficient implementation.
+    async fn remount(&self, handle: &MountHandle, config: &VolumeConfig) -> Result<MountHandle> {
+        // Default implementation: unmount and mount again
+        self.unmount(handle).await.ok(); // Ignore unmount errors
+
+        self.mount(config, handle.tunnel_port, "dev").await
+    }
+
+    /// Returns the packages required on the remote VM for this driver
+    ///
+    /// These packages will be installed via cloud-init or the agent.
+    fn required_packages(&self) -> Vec<&'static str>;
+
+    /// Returns the packages required on the local machine for this driver
+    fn required_local_packages(&self) -> Vec<&'static str> {
+        vec![]
+    }
+
+    /// Check if a mount is still active
+    ///
+    /// Default implementation checks the mount status.
+    async fn is_mounted(&self, handle: &MountHandle) -> bool {
+        match self.status(handle).await {
+            Ok(status) => status.mounted,
+            Err(_) => false,
+        }
+    }
+}
+
+/// Information about a volume driver
+#[derive(Debug, Clone)]
+pub struct DriverInfo {
+    /// Driver name
+    pub name: &'static str,
+
+    /// Human-readable description
+    pub description: &'static str,
+
+    /// Required packages on remote VM
+    pub remote_packages: Vec<&'static str>,
+
+    /// Required packages on local machine
+    pub local_packages: Vec<&'static str>,
+
+    /// Whether the driver is available on this system
+    pub available: bool,
+}
+
+impl DriverInfo {
+    /// Create driver info from a driver instance
+    pub async fn from_driver<D: VolumeDriver + ?Sized>(driver: &D) -> Self {
+        Self {
+            name: driver.name(),
+            description: driver.description(),
+            remote_packages: driver.required_packages(),
+            local_packages: driver.required_local_packages(),
+            available: driver.is_available().await,
+        }
+    }
+}

--- a/src/volume/drivers/mod.rs
+++ b/src/volume/drivers/mod.rs
@@ -1,0 +1,8 @@
+//! Volume driver implementations
+//!
+//! This module contains implementations of the `VolumeDriver` trait
+//! for different mount protocols.
+
+pub mod sshfs;
+
+pub use sshfs::{get_install_instructions, SshfsDriver, SshfsLocalCommands};

--- a/src/volume/drivers/sshfs.rs
+++ b/src/volume/drivers/sshfs.rs
@@ -1,0 +1,614 @@
+//! SSHFS volume driver implementation
+//!
+//! Mounts remote VM directories locally using SSHFS.
+//! This allows local editors to work with files that live on the VM.
+//!
+//! # Flow
+//! 1. User runs `spuff volume mount`
+//! 2. Local machine runs SSHFS to mount VM directory locally
+//! 3. Edits in local editor go directly to VM
+//!
+//! # Requirements
+//! - macOS: macFUSE + SSHFS (brew install macfuse sshfs)
+//! - Linux: fuse + sshfs (apt install sshfs)
+
+use std::process::Stdio;
+use std::time::Instant;
+
+use async_trait::async_trait;
+use tokio::process::Command;
+
+use crate::error::{Result, SpuffError};
+use crate::volume::config::VolumeConfig;
+use crate::volume::driver::VolumeDriver;
+use crate::volume::state::{MountHandle, MountStatus};
+
+/// SSHFS volume driver
+///
+/// Mounts remote VM directories locally using SSHFS over SSH.
+#[derive(Debug, Clone, Default)]
+pub struct SshfsDriver;
+
+impl SshfsDriver {
+    /// Create a new SSHFS driver instance
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Check if SSHFS is installed locally
+    pub async fn check_sshfs_installed() -> bool {
+        Command::new("which")
+            .arg("sshfs")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .await
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+
+    /// Check if macFUSE/FUSE is available
+    pub async fn check_fuse_available() -> bool {
+        #[cfg(target_os = "macos")]
+        {
+            // Check for macFUSE
+            std::path::Path::new("/Library/Filesystems/macfuse.fs").exists()
+                || std::path::Path::new("/usr/local/lib/libfuse.dylib").exists()
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            std::path::Path::new("/dev/fuse").exists()
+        }
+
+        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+        {
+            false
+        }
+    }
+}
+
+#[async_trait]
+impl VolumeDriver for SshfsDriver {
+    fn name(&self) -> &'static str {
+        "sshfs"
+    }
+
+    fn description(&self) -> &'static str {
+        "SSH Filesystem - mount remote VM directories locally"
+    }
+
+    async fn is_available(&self) -> bool {
+        Self::check_sshfs_installed().await && Self::check_fuse_available().await
+    }
+
+    async fn mount(
+        &self,
+        config: &VolumeConfig,
+        _tunnel_port: Option<u16>,
+        _remote_user: &str,
+    ) -> Result<MountHandle> {
+        // This method prepares the mount handle
+        // The actual mount is done by SshfsLocalCommands::mount()
+        // Note: project_base_dir is None here as this is called without project context
+        let mount_point = config.resolve_mount_point(None, None);
+
+        let handle = MountHandle::new(self.name(), &config.target, &mount_point)
+            .with_read_only(config.read_only);
+
+        tracing::info!(
+            "Prepared SSHFS mount: VM:{} -> Local:{}",
+            config.target,
+            mount_point
+        );
+
+        Ok(handle)
+    }
+
+    async fn unmount(&self, handle: &MountHandle) -> Result<()> {
+        SshfsLocalCommands::unmount(&handle.mount_point).await
+    }
+
+    async fn status(&self, handle: &MountHandle) -> Result<MountStatus> {
+        SshfsLocalCommands::check_status(&handle.mount_point).await
+    }
+
+    fn required_packages(&self) -> Vec<&'static str> {
+        // No packages needed on the VM for this direction
+        vec![]
+    }
+
+    fn required_local_packages(&self) -> Vec<&'static str> {
+        #[cfg(target_os = "macos")]
+        {
+            vec!["macfuse", "sshfs"]
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            vec!["sshfs", "fuse3"]
+        }
+
+        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+        {
+            vec!["sshfs"]
+        }
+    }
+}
+
+/// Commands to execute locally for SSHFS operations
+pub struct SshfsLocalCommands;
+
+impl SshfsLocalCommands {
+    /// Mount a remote directory locally using SSHFS
+    ///
+    /// # Arguments
+    /// * `vm_ip` - IP address of the VM
+    /// * `ssh_user` - SSH username on the VM
+    /// * `ssh_key_path` - Path to SSH private key
+    /// * `remote_path` - Path on the VM to mount
+    /// * `local_mount_point` - Local directory to mount to
+    /// * `read_only` - Mount as read-only
+    /// * `options` - Additional mount options
+    pub async fn mount(
+        vm_ip: &str,
+        ssh_user: &str,
+        ssh_key_path: &str,
+        remote_path: &str,
+        local_mount_point: &str,
+        read_only: bool,
+        options: &crate::volume::config::VolumeOptions,
+    ) -> Result<()> {
+        // Create mount point directory
+        std::fs::create_dir_all(local_mount_point).map_err(|e| {
+            SpuffError::Volume(format!(
+                "Failed to create mount point {}: {}",
+                local_mount_point, e
+            ))
+        })?;
+
+        // Ensure remote directory exists (SSHFS fails silently if it doesn't)
+        Self::ensure_remote_dir_exists(vm_ip, ssh_user, ssh_key_path, remote_path).await?;
+
+        // SSHFS 2.x has issues with paths containing spaces in IdentityFile option.
+        // Create a wrapper script to handle SSH options properly.
+        let wrapper_path = Self::create_ssh_wrapper(ssh_key_path, options)?;
+
+        let mut args = vec![
+            "-o".to_string(),
+            format!("ssh_command={}", wrapper_path.display()),
+        ];
+
+        // Add reconnect option
+        if options.reconnect {
+            args.extend(["-o".to_string(), "reconnect".to_string()]);
+        }
+
+        // Add compression
+        if options.compression {
+            args.extend(["-o".to_string(), "compression=yes".to_string()]);
+        }
+
+        // Add read-only
+        if read_only {
+            args.extend(["-o".to_string(), "ro".to_string()]);
+        }
+
+        // Add caching options
+        if options.cache {
+            args.extend([
+                "-o".to_string(),
+                "cache=yes".to_string(),
+                "-o".to_string(),
+                "kernel_cache".to_string(),
+                "-o".to_string(),
+                "auto_cache".to_string(),
+            ]);
+        }
+
+        // macOS specific options
+        #[cfg(target_os = "macos")]
+        {
+            // Disable extended attributes to avoid issues
+            args.extend(["-o".to_string(), "noapplexattr".to_string()]);
+
+            // Set volume name for Finder
+            let volume_name = std::path::Path::new(remote_path)
+                .file_name()
+                .map(|n| n.to_string_lossy().to_string())
+                .unwrap_or_else(|| "spuff".to_string());
+            args.extend(["-o".to_string(), format!("volname={}", volume_name)]);
+        }
+
+        // Source (remote path)
+        args.push(format!("{}@{}:{}", ssh_user, vm_ip, remote_path));
+
+        // Target (local mount point)
+        args.push(local_mount_point.to_string());
+
+        tracing::debug!("Running: sshfs {:?}", args);
+
+        let output = Command::new("sshfs")
+            .args(&args)
+            .output()
+            .await
+            .map_err(|e| SpuffError::Volume(format!("Failed to execute sshfs: {}", e)))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+
+            // Provide helpful error messages
+            if stderr.contains("mount_macfuse") || stderr.contains("fuse") {
+                return Err(SpuffError::Volume(
+                    "macFUSE is not installed or not loaded.\n\n\
+                     Install with: brew install macfuse\n\
+                     Then restart your computer.\n\n\
+                     If already installed, you may need to allow the kernel extension in:\n\
+                     System Settings > Privacy & Security"
+                        .to_string(),
+                ));
+            }
+
+            if stderr.contains("Permission denied") {
+                return Err(SpuffError::Volume(format!(
+                    "SSH authentication failed. Check that:\n\
+                     - The VM is running\n\
+                     - SSH key is correct: {}\n\
+                     - User '{}' exists on the VM\n\n\
+                     Error: {}",
+                    ssh_key_path, ssh_user, stderr
+                )));
+            }
+
+            return Err(SpuffError::Volume(format!(
+                "Failed to mount SSHFS: {}",
+                stderr
+            )));
+        }
+
+        tracing::info!(
+            "Mounted {}@{}:{} at {}",
+            ssh_user,
+            vm_ip,
+            remote_path,
+            local_mount_point
+        );
+
+        Ok(())
+    }
+
+    /// Create a wrapper script for SSH to handle paths with spaces
+    /// SSHFS 2.x cannot properly handle IdentityFile paths with spaces
+    fn create_ssh_wrapper(
+        ssh_key_path: &str,
+        options: &crate::volume::config::VolumeOptions,
+    ) -> Result<std::path::PathBuf> {
+        let wrapper_dir = dirs::cache_dir()
+            .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
+            .join("spuff")
+            .join("ssh-wrappers");
+
+        std::fs::create_dir_all(&wrapper_dir).map_err(|e| {
+            SpuffError::Volume(format!("Failed to create SSH wrapper directory: {}", e))
+        })?;
+
+        // Use a hash of the key path to create a unique wrapper per key
+        let hash = {
+            use std::collections::hash_map::DefaultHasher;
+            use std::hash::{Hash, Hasher};
+            let mut hasher = DefaultHasher::new();
+            ssh_key_path.hash(&mut hasher);
+            hasher.finish()
+        };
+
+        let wrapper_path = wrapper_dir.join(format!("ssh-wrapper-{:x}.sh", hash));
+
+        let script_content = format!(
+            r#"#!/bin/bash
+exec ssh -i "{}" -o IdentitiesOnly=yes -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ServerAliveInterval={} -o ServerAliveCountMax={} "$@"
+"#,
+            ssh_key_path, options.server_alive_interval, options.server_alive_count_max
+        );
+
+        std::fs::write(&wrapper_path, &script_content).map_err(|e| {
+            SpuffError::Volume(format!("Failed to write SSH wrapper script: {}", e))
+        })?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&wrapper_path, std::fs::Permissions::from_mode(0o755))
+                .map_err(|e| {
+                    SpuffError::Volume(format!(
+                        "Failed to set permissions on SSH wrapper script: {}",
+                        e
+                    ))
+                })?;
+        }
+
+        tracing::debug!("Created SSH wrapper script: {}", wrapper_path.display());
+
+        Ok(wrapper_path)
+    }
+
+    /// Ensure the remote directory exists before mounting
+    /// SSHFS fails silently with "remote host has disconnected" if the directory doesn't exist
+    async fn ensure_remote_dir_exists(
+        vm_ip: &str,
+        ssh_user: &str,
+        ssh_key_path: &str,
+        remote_path: &str,
+    ) -> Result<()> {
+        let output = Command::new("ssh")
+            .args([
+                "-i",
+                ssh_key_path,
+                "-o",
+                "IdentitiesOnly=yes",
+                "-o",
+                "StrictHostKeyChecking=no",
+                "-o",
+                "UserKnownHostsFile=/dev/null",
+                "-o",
+                "BatchMode=yes",
+                "-o",
+                "ConnectTimeout=10",
+                &format!("{}@{}", ssh_user, vm_ip),
+                &format!("mkdir -p \"{}\"", remote_path),
+            ])
+            .output()
+            .await
+            .map_err(|e| {
+                SpuffError::Volume(format!("Failed to create remote directory via SSH: {}", e))
+            })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(SpuffError::Volume(format!(
+                "Failed to create remote directory '{}': {}",
+                remote_path, stderr
+            )));
+        }
+
+        tracing::debug!("Ensured remote directory exists: {}", remote_path);
+        Ok(())
+    }
+
+    /// Unmount a local SSHFS mount point
+    pub async fn unmount(mount_point: &str) -> Result<()> {
+        // Check if mounted first
+        if !Self::is_mounted(mount_point).await {
+            tracing::debug!(
+                "Mount point {} is not mounted, skipping unmount",
+                mount_point
+            );
+            return Ok(());
+        }
+
+        // Try normal unmount first
+        #[cfg(target_os = "macos")]
+        {
+            let output = Command::new("umount")
+                .arg(mount_point)
+                .output()
+                .await
+                .map_err(|e| SpuffError::Volume(format!("Failed to execute umount: {}", e)))?;
+
+            if output.status.success() {
+                tracing::info!("Unmounted {}", mount_point);
+                return Ok(());
+            }
+
+            // Try force unmount with umount -f
+            let force_output = Command::new("umount")
+                .args(["-f", mount_point])
+                .output()
+                .await;
+
+            if let Ok(out) = force_output {
+                if out.status.success() {
+                    tracing::info!("Force unmounted {} with umount -f", mount_point);
+                    return Ok(());
+                }
+            }
+
+            // Last resort: diskutil unmount force
+            let diskutil_output = Command::new("diskutil")
+                .args(["unmount", "force", mount_point])
+                .output()
+                .await;
+
+            if let Ok(out) = diskutil_output {
+                if out.status.success() {
+                    tracing::info!("Force unmounted {} with diskutil", mount_point);
+                    return Ok(());
+                }
+            }
+
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            Err(SpuffError::Volume(format!(
+                "Failed to unmount {}: {}",
+                mount_point, stderr
+            )))
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            // Try normal unmount first
+            let output = Command::new("fusermount")
+                .args(["-u", mount_point])
+                .output()
+                .await
+                .map_err(|e| SpuffError::Volume(format!("Failed to execute fusermount: {}", e)))?;
+
+            if output.status.success() {
+                tracing::info!("Unmounted {}", mount_point);
+                return Ok(());
+            }
+
+            // Try lazy unmount (detaches immediately, cleans up when not busy)
+            let lazy_output = Command::new("fusermount")
+                .args(["-uz", mount_point])
+                .output()
+                .await;
+
+            if let Ok(out) = lazy_output {
+                if out.status.success() {
+                    tracing::info!("Lazy unmounted {} with fusermount -uz", mount_point);
+                    return Ok(());
+                }
+            }
+
+            // Try umount -l as last resort
+            let umount_lazy = Command::new("umount")
+                .args(["-l", mount_point])
+                .output()
+                .await;
+
+            if let Ok(out) = umount_lazy {
+                if out.status.success() {
+                    tracing::info!("Lazy unmounted {} with umount -l", mount_point);
+                    return Ok(());
+                }
+            }
+
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            Err(SpuffError::Volume(format!(
+                "Failed to unmount {}: {}",
+                mount_point, stderr
+            )))
+        }
+
+        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+        {
+            Err(SpuffError::Volume(
+                "Unmount not supported on this platform".to_string(),
+            ))
+        }
+    }
+
+    /// Check if a path is currently mounted
+    pub async fn is_mounted(mount_point: &str) -> bool {
+        #[cfg(target_os = "macos")]
+        {
+            let output = Command::new("mount").output().await.ok();
+
+            if let Some(out) = output {
+                let stdout = String::from_utf8_lossy(&out.stdout);
+                return stdout.contains(mount_point);
+            }
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            let output = Command::new("mountpoint")
+                .arg("-q")
+                .arg(mount_point)
+                .status()
+                .await
+                .ok();
+
+            if let Some(status) = output {
+                return status.success();
+            }
+        }
+
+        false
+    }
+
+    /// Check mount status and health
+    pub async fn check_status(mount_point: &str) -> Result<MountStatus> {
+        if !Self::is_mounted(mount_point).await {
+            return Ok(MountStatus::not_mounted());
+        }
+
+        // Try to access the mount point to check health
+        let start = Instant::now();
+        let accessible = tokio::fs::read_dir(mount_point).await.is_ok();
+        let latency = start.elapsed().as_millis() as u64;
+
+        if accessible {
+            Ok(MountStatus::healthy().with_latency(latency))
+        } else {
+            Ok(MountStatus::unhealthy("Mount point not accessible"))
+        }
+    }
+}
+
+/// Get installation instructions for SSHFS
+pub fn get_install_instructions() -> &'static str {
+    #[cfg(target_os = "macos")]
+    {
+        "SSHFS is not installed.\n\n\
+         Install with Homebrew:\n\
+         brew install macfuse sshfs\n\n\
+         After installation, restart your computer.\n\
+         You may need to allow the kernel extension in:\n\
+         System Settings > Privacy & Security"
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        "SSHFS is not installed.\n\n\
+         Install with your package manager:\n\
+         Ubuntu/Debian: sudo apt install sshfs\n\
+         Fedora: sudo dnf install fuse-sshfs\n\
+         Arch: sudo pacman -S sshfs"
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        "SSHFS is not available on this platform."
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sshfs_driver_name() {
+        let driver = SshfsDriver::new();
+        assert_eq!(driver.name(), "sshfs");
+    }
+
+    #[test]
+    fn test_sshfs_driver_description() {
+        let driver = SshfsDriver::new();
+        assert!(driver.description().contains("remote"));
+    }
+
+    #[test]
+    fn test_sshfs_required_local_packages() {
+        let driver = SshfsDriver::new();
+        let packages = driver.required_local_packages();
+        assert!(packages.contains(&"sshfs"));
+    }
+
+    #[tokio::test]
+    async fn test_check_sshfs_installed() {
+        // This test just verifies the function runs without panic
+        let _ = SshfsDriver::check_sshfs_installed().await;
+    }
+
+    #[tokio::test]
+    async fn test_check_fuse_available() {
+        // This test just verifies the function runs without panic
+        let _ = SshfsDriver::check_fuse_available().await;
+    }
+
+    #[test]
+    fn test_mount_status_not_mounted() {
+        let status = MountStatus::not_mounted();
+        assert!(!status.mounted);
+        assert!(!status.healthy);
+    }
+
+    #[test]
+    fn test_mount_status_healthy_with_latency() {
+        let status = MountStatus::healthy().with_latency(42);
+        assert!(status.mounted);
+        assert!(status.healthy);
+        assert_eq!(status.latency_ms, Some(42));
+    }
+}

--- a/src/volume/mod.rs
+++ b/src/volume/mod.rs
@@ -1,0 +1,259 @@
+//! Volume mounting module for spuff
+//!
+//! Provides an extensible architecture for mounting local directories on remote VMs.
+//! Currently supports SSHFS with plans for NFS, 9P, and other protocols.
+//!
+//! # Architecture
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────────┐
+//! │                      VolumeManager                           │
+//! │  ┌───────────────────────────────────────────────────────┐  │
+//! │  │                  trait VolumeDriver                   │  │
+//! │  │  + mount(config) -> MountHandle                       │  │
+//! │  │  + unmount(handle) -> Result<()>                      │  │
+//! │  │  + status(handle) -> MountStatus                      │  │
+//! │  └───────────────────────────────────────────────────────┘  │
+//! │                              │                               │
+//! │         ┌────────────────────┼────────────────────┐         │
+//! │         ▼                    ▼                    ▼         │
+//! │  ┌─────────────┐     ┌─────────────┐      ┌─────────────┐   │
+//! │  │ SshfsDriver │     │  NfsDriver  │      │  9PDriver   │   │
+//! │  │ (v1 - now)  │     │  (future)   │      │  (future)   │   │
+//! │  └─────────────┘     └─────────────┘      └─────────────┘   │
+//! └─────────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! # Usage
+//!
+//! ```yaml
+//! # spuff.yaml
+//! volumes:
+//!   - source: ./src
+//!     target: /home/dev/project
+//!   - source: ~/.config/nvim
+//!     target: /home/dev/.config/nvim
+//!     read_only: true
+//! ```
+
+pub mod config;
+pub mod driver;
+pub mod drivers;
+pub mod state;
+
+pub use config::{VolumeConfig, VolumeOptions, VolumeType};
+pub use driver::{DriverInfo, VolumeDriver};
+pub use drivers::{get_install_instructions, SshfsDriver, SshfsLocalCommands};
+pub use state::{MountHandle, MountStatus, VolumeState};
+
+use std::collections::HashMap;
+
+use crate::error::{Result, SpuffError};
+
+/// Manages volume mounting operations
+///
+/// The VolumeManager maintains a registry of available drivers and
+/// provides a unified interface for mounting/unmounting volumes.
+pub struct VolumeManager {
+    /// Registered volume drivers
+    drivers: HashMap<VolumeType, Box<dyn VolumeDriver>>,
+
+    /// Current volume state (persisted)
+    state: VolumeState,
+}
+
+impl Default for VolumeManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl VolumeManager {
+    /// Create a new VolumeManager with default drivers
+    pub fn new() -> Self {
+        let mut drivers: HashMap<VolumeType, Box<dyn VolumeDriver>> = HashMap::new();
+
+        // Register default drivers
+        drivers.insert(VolumeType::Sshfs, Box::new(SshfsDriver::new()));
+
+        // Load persisted state or create new
+        let state = VolumeState::load().unwrap_or_default();
+
+        Self { drivers, state }
+    }
+
+    /// Get a driver by volume type
+    pub fn get_driver(&self, volume_type: &VolumeType) -> Option<&dyn VolumeDriver> {
+        self.drivers.get(volume_type).map(|d| d.as_ref())
+    }
+
+    /// Get information about all registered drivers
+    pub async fn get_driver_info(&self) -> Vec<DriverInfo> {
+        let mut infos = Vec::new();
+
+        for driver in self.drivers.values() {
+            infos.push(DriverInfo::from_driver(driver.as_ref()).await);
+        }
+
+        infos
+    }
+
+    /// Get required packages for a list of volume configs
+    pub fn get_required_packages(&self, volumes: &[VolumeConfig]) -> Vec<&'static str> {
+        let mut packages = Vec::new();
+
+        for volume in volumes {
+            if let Some(driver) = self.drivers.get(&volume.driver_type) {
+                packages.extend(driver.required_packages());
+            }
+        }
+
+        packages.sort();
+        packages.dedup();
+        packages
+    }
+
+    /// Mount a single volume
+    pub async fn mount(
+        &mut self,
+        config: &VolumeConfig,
+        tunnel_port: Option<u16>,
+        remote_user: &str,
+    ) -> Result<MountHandle> {
+        let driver = self.drivers.get(&config.driver_type).ok_or_else(|| {
+            SpuffError::Volume(format!("Unknown driver type: {:?}", config.driver_type))
+        })?;
+
+        let handle = driver.mount(config, tunnel_port, remote_user).await?;
+
+        // Save to state
+        self.state.add_mount(handle.clone());
+        self.state.save().ok();
+
+        Ok(handle)
+    }
+
+    /// Mount all volumes from a list of configs
+    pub async fn mount_all(
+        &mut self,
+        volumes: &[VolumeConfig],
+        tunnel_port: Option<u16>,
+        remote_user: &str,
+    ) -> Vec<Result<MountHandle>> {
+        let mut results = Vec::new();
+
+        for volume in volumes {
+            let result = self.mount(volume, tunnel_port, remote_user).await;
+
+            if let Err(ref e) = result {
+                tracing::warn!("Failed to mount {}: {}", volume.target, e);
+            }
+
+            results.push(result);
+        }
+
+        results
+    }
+
+    /// Unmount a volume by target path
+    pub async fn unmount(&mut self, target: &str) -> Result<()> {
+        let handle = self
+            .state
+            .find_mount(target)
+            .ok_or_else(|| SpuffError::Volume(format!("Mount not found: {}", target)))?
+            .clone();
+
+        let driver_type: VolumeType = handle.driver.parse().unwrap_or_default();
+        let driver = self
+            .drivers
+            .get(&driver_type)
+            .ok_or_else(|| SpuffError::Volume(format!("Unknown driver type: {}", handle.driver)))?;
+
+        driver.unmount(&handle).await?;
+
+        // Remove from state
+        self.state.remove_mount(target);
+        self.state.save().ok();
+
+        Ok(())
+    }
+
+    /// Unmount all volumes
+    pub async fn unmount_all(&mut self) -> Vec<Result<()>> {
+        let targets: Vec<String> = self.state.mounts.iter().map(|m| m.target.clone()).collect();
+
+        let mut results = Vec::new();
+
+        for target in targets {
+            results.push(self.unmount(&target).await);
+        }
+
+        results
+    }
+
+    /// Get status of all mounts
+    pub async fn status_all(&self) -> Vec<(MountHandle, MountStatus)> {
+        let mut statuses = Vec::new();
+
+        for handle in &self.state.mounts {
+            let driver_type: VolumeType = handle.driver.parse().unwrap_or_default();
+
+            let status = if let Some(driver) = self.drivers.get(&driver_type) {
+                driver.status(handle).await.unwrap_or_default()
+            } else {
+                MountStatus::default()
+            };
+
+            statuses.push((handle.clone(), status));
+        }
+
+        statuses
+    }
+
+    /// Get current mount handles
+    pub fn get_mounts(&self) -> &[MountHandle] {
+        &self.state.mounts
+    }
+
+    /// Clear all mount state (for cleanup)
+    pub fn clear_state(&mut self) {
+        self.state.clear();
+        self.state.save().ok();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_volume_manager_new() {
+        let manager = VolumeManager::new();
+        assert!(manager.get_driver(&VolumeType::Sshfs).is_some());
+    }
+
+    #[test]
+    fn test_get_required_packages() {
+        let manager = VolumeManager::new();
+        let volumes = vec![VolumeConfig::new("./src", "/mnt/src")];
+
+        let packages = manager.get_required_packages(&volumes);
+        // With the new Local -> VM architecture, SSHFS runs locally
+        // so no packages are needed on the VM
+        assert!(packages.is_empty());
+    }
+
+    #[test]
+    fn test_get_required_packages_dedup() {
+        let manager = VolumeManager::new();
+        let volumes = vec![
+            VolumeConfig::new("./src", "/mnt/src"),
+            VolumeConfig::new("./lib", "/mnt/lib"),
+        ];
+
+        let packages = manager.get_required_packages(&volumes);
+        // Should not have duplicates (even though list is empty with SSHFS)
+        let unique: std::collections::HashSet<_> = packages.iter().collect();
+        assert_eq!(packages.len(), unique.len());
+    }
+}

--- a/src/volume/state.rs
+++ b/src/volume/state.rs
@@ -1,0 +1,313 @@
+//! Volume mount state tracking
+//!
+//! Defines types for tracking mounted volumes and their status.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Handle to a mounted volume
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MountHandle {
+    /// Unique identifier for this mount
+    pub id: String,
+
+    /// Driver used for the mount (e.g., "sshfs")
+    pub driver: String,
+
+    /// Source path (local, for sync drivers like rsync)
+    pub source: String,
+
+    /// Target path on the remote VM
+    pub target: String,
+
+    /// Local mount point where the remote directory is mounted
+    pub mount_point: String,
+
+    /// VM IP address (needed for unmount)
+    pub vm_ip: Option<String>,
+
+    /// SSH user on the VM
+    pub ssh_user: Option<String>,
+
+    /// Port used for SSH connection (if applicable)
+    pub tunnel_port: Option<u16>,
+
+    /// When the volume was mounted
+    pub mounted_at: DateTime<Utc>,
+
+    /// Whether the mount is read-only
+    pub read_only: bool,
+}
+
+impl MountHandle {
+    /// Create a new mount handle
+    pub fn new(
+        driver: impl Into<String>,
+        target: impl Into<String>,
+        mount_point: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: uuid::Uuid::new_v4().to_string(),
+            driver: driver.into(),
+            source: String::new(),
+            target: target.into(),
+            mount_point: mount_point.into(),
+            vm_ip: None,
+            ssh_user: None,
+            tunnel_port: None,
+            mounted_at: Utc::now(),
+            read_only: false,
+        }
+    }
+
+    /// Set the source path (for sync drivers)
+    pub fn with_source(mut self, source: impl Into<String>) -> Self {
+        self.source = source.into();
+        self
+    }
+
+    /// Set the VM connection info
+    pub fn with_vm_info(mut self, ip: impl Into<String>, user: impl Into<String>) -> Self {
+        self.vm_ip = Some(ip.into());
+        self.ssh_user = Some(user.into());
+        self
+    }
+
+    /// Set the SSH port
+    pub fn with_tunnel_port(mut self, port: u16) -> Self {
+        self.tunnel_port = Some(port);
+        self
+    }
+
+    /// Set read-only flag
+    pub fn with_read_only(mut self, read_only: bool) -> Self {
+        self.read_only = read_only;
+        self
+    }
+}
+
+/// Status of a mounted volume
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MountStatus {
+    /// Whether the volume is currently mounted
+    pub mounted: bool,
+
+    /// Whether the mount is healthy (accessible)
+    pub healthy: bool,
+
+    /// Latency to the mount point in milliseconds
+    pub latency_ms: Option<u64>,
+
+    /// Bytes read since mount (if available)
+    pub bytes_read: Option<u64>,
+
+    /// Bytes written since mount (if available)
+    pub bytes_written: Option<u64>,
+
+    /// Error message if unhealthy
+    pub error: Option<String>,
+}
+
+impl MountStatus {
+    /// Create a healthy mount status
+    pub fn healthy() -> Self {
+        Self {
+            mounted: true,
+            healthy: true,
+            ..Default::default()
+        }
+    }
+
+    /// Create an unhealthy mount status with error
+    pub fn unhealthy(error: impl Into<String>) -> Self {
+        Self {
+            mounted: true,
+            healthy: false,
+            error: Some(error.into()),
+            ..Default::default()
+        }
+    }
+
+    /// Create a not-mounted status
+    pub fn not_mounted() -> Self {
+        Self::default()
+    }
+
+    /// Set latency
+    pub fn with_latency(mut self, latency_ms: u64) -> Self {
+        self.latency_ms = Some(latency_ms);
+        self
+    }
+}
+
+/// Persistent state for volumes
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct VolumeState {
+    /// Currently active mount handles
+    pub mounts: Vec<MountHandle>,
+}
+
+impl VolumeState {
+    /// Load state from the default location
+    pub fn load() -> Option<Self> {
+        let state_dir = dirs::data_local_dir()?.join("spuff");
+        let state_file = state_dir.join("volumes.json");
+
+        if !state_file.exists() {
+            return None;
+        }
+
+        let content = std::fs::read_to_string(&state_file).ok()?;
+        serde_json::from_str(&content).ok()
+    }
+
+    /// Save state to the default location
+    pub fn save(&self) -> std::io::Result<()> {
+        let state_dir = dirs::data_local_dir()
+            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "No data dir"))?
+            .join("spuff");
+
+        std::fs::create_dir_all(&state_dir)?;
+        let state_file = state_dir.join("volumes.json");
+
+        let content = serde_json::to_string_pretty(self)?;
+        std::fs::write(state_file, content)
+    }
+
+    /// Add a mount handle
+    pub fn add_mount(&mut self, handle: MountHandle) {
+        self.mounts.push(handle);
+    }
+
+    /// Remove a mount handle by target path or mount point
+    pub fn remove_mount(&mut self, path: &str) -> Option<MountHandle> {
+        if let Some(pos) = self
+            .mounts
+            .iter()
+            .position(|m| m.target == path || m.mount_point == path)
+        {
+            Some(self.mounts.remove(pos))
+        } else {
+            None
+        }
+    }
+
+    /// Find a mount handle by target path or mount point
+    pub fn find_mount(&self, path: &str) -> Option<&MountHandle> {
+        self.mounts
+            .iter()
+            .find(|m| m.target == path || m.mount_point == path)
+    }
+
+    /// Find a mount handle by local mount point
+    pub fn find_by_mount_point(&self, mount_point: &str) -> Option<&MountHandle> {
+        self.mounts.iter().find(|m| m.mount_point == mount_point)
+    }
+
+    /// Clear all mounts
+    pub fn clear(&mut self) {
+        self.mounts.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mount_handle_new() {
+        // new(driver, target, mount_point)
+        let handle = MountHandle::new("sshfs", "/home/dev/project", "/local/mnt");
+        assert!(!handle.id.is_empty());
+        assert_eq!(handle.driver, "sshfs");
+        assert_eq!(handle.target, "/home/dev/project");
+        assert_eq!(handle.mount_point, "/local/mnt");
+        assert!(handle.source.is_empty());
+        assert!(handle.tunnel_port.is_none());
+        assert!(!handle.read_only);
+    }
+
+    #[test]
+    fn test_mount_handle_with_vm_info() {
+        let handle = MountHandle::new("sshfs", "/home/dev/project", "/local/mnt")
+            .with_vm_info("192.168.1.100", "dev");
+        assert_eq!(handle.vm_ip, Some("192.168.1.100".to_string()));
+        assert_eq!(handle.ssh_user, Some("dev".to_string()));
+    }
+
+    #[test]
+    fn test_mount_handle_with_source() {
+        let handle =
+            MountHandle::new("sshfs", "/home/dev/project", "/local/mnt").with_source("./src");
+        assert_eq!(handle.source, "./src");
+    }
+
+    #[test]
+    fn test_mount_status_healthy() {
+        let status = MountStatus::healthy();
+        assert!(status.mounted);
+        assert!(status.healthy);
+        assert!(status.error.is_none());
+    }
+
+    #[test]
+    fn test_mount_status_unhealthy() {
+        let status = MountStatus::unhealthy("Connection lost");
+        assert!(status.mounted);
+        assert!(!status.healthy);
+        assert_eq!(status.error, Some("Connection lost".to_string()));
+    }
+
+    #[test]
+    fn test_mount_status_with_latency() {
+        let status = MountStatus::healthy().with_latency(25);
+        assert_eq!(status.latency_ms, Some(25));
+    }
+
+    #[test]
+    fn test_volume_state_add_remove() {
+        let mut state = VolumeState::default();
+        assert!(state.mounts.is_empty());
+
+        let handle = MountHandle::new("sshfs", "/home/dev/project", "/local/mnt");
+        state.add_mount(handle);
+        assert_eq!(state.mounts.len(), 1);
+
+        // Can remove by target
+        let removed = state.remove_mount("/home/dev/project");
+        assert!(removed.is_some());
+        assert!(state.mounts.is_empty());
+    }
+
+    #[test]
+    fn test_volume_state_remove_by_mount_point() {
+        let mut state = VolumeState::default();
+        state.add_mount(MountHandle::new("sshfs", "/home/dev/project", "/local/mnt"));
+
+        // Can also remove by mount_point
+        let removed = state.remove_mount("/local/mnt");
+        assert!(removed.is_some());
+        assert!(state.mounts.is_empty());
+    }
+
+    #[test]
+    fn test_volume_state_find_mount() {
+        let mut state = VolumeState::default();
+        state.add_mount(MountHandle::new("sshfs", "/home/dev/project", "/local/mnt"));
+
+        // Find by target
+        assert!(state.find_mount("/home/dev/project").is_some());
+        // Find by mount_point
+        assert!(state.find_mount("/local/mnt").is_some());
+        assert!(state.find_mount("/nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_volume_state_find_by_mount_point() {
+        let mut state = VolumeState::default();
+        state.add_mount(MountHandle::new("sshfs", "/home/dev/project", "/local/mnt"));
+
+        assert!(state.find_by_mount_point("/local/mnt").is_some());
+        assert!(state.find_by_mount_point("/home/dev/project").is_none());
+    }
+}


### PR DESCRIPTION
* Implement volume module with SSHFS driver for mounting local directories on remote VMs
* Add `spuff volume mount/unmount/ls` CLI commands for manual volume management
* Integrate auto-mount/unmount with `spuff up` and `spuff down` lifecycle
* Add volume management endpoints to the agent for remote directory operations


fixed: #5 